### PR TITLE
Fix template authors displaying as numeric ids

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
@@ -143,8 +143,9 @@ class ProjectController {
         if (projectInstance && userService.isAdmin()) {
             def userIds = taskService.getUserIdsForProject(projectInstance)
             log.debug("userIds = " + userIds)
+            def userEmails = userService.getEmailAddressesForIds(userIds)
             //render(userIds)
-            def list = userIds.join(";\n")
+            def list = userEmails.join(";\n")
             render(text:list, contentType: "text/plain")
         }
         else if (projectInstance) {

--- a/grails-app/controllers/au/org/ala/volunteer/TemplateController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TemplateController.groovy
@@ -22,11 +22,13 @@ class TemplateController {
 
     def create = {
         def templateInstance = new Template()
+        templateInstance.author = userService.currentUserId
         templateInstance.properties = params
         return [templateInstance: templateInstance, availableViews: templateService.getAvailableTemplateViews()]
     }
 
     def save = {
+        params.author = userService.currentUserId
         def templateInstance = new Template(params)
         if (templateInstance.save(flush: true)) {
             flash.message = "${message(code: 'default.created.message', args: [message(code: 'template.label', default: 'Template'), templateInstance.id])}"

--- a/grails-app/controllers/au/org/ala/volunteer/UserController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/UserController.groovy
@@ -15,6 +15,7 @@ class UserController {
     def logService
     def fieldService
     def forumService
+    def authService
 
     def index = {
         redirect(action: "list", params: params)
@@ -321,7 +322,7 @@ class UserController {
         
         def roles = UserRole.findAllByUser(userInstance)
         
-        return [userInstance: userInstance, roles: roles]
+        return [userInstance: userInstance, roles: roles, userDetails: authService.getUserForUserId(userInstance.getUserId())]
     }
 
     def update = {

--- a/grails-app/domain/au/org/ala/volunteer/Template.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/Template.groovy
@@ -15,7 +15,7 @@ class Template implements Serializable {
     }
 
     static constraints = {
-        author maxSize: 200, email: true, nullable: true
+        author maxSize: 200, nullable: true
         name maxSize: 200
         viewName nullable: true
         viewParams nullable: true

--- a/grails-app/services/au/org/ala/volunteer/UserService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/UserService.groovy
@@ -321,4 +321,32 @@ class UserService {
             logService.log("${purgeCount} activity records purged from database")
         }
     }
+
+    List<String> getEmailAddressesForIds(List<String> userIds) {
+        userIds.collect { authService.getUserForUserId(it).userName }
+    }
+
+    def propForUserId(String userid, String prop) {
+        if (!userid) return ''
+        else if ('system' == userid) return userid
+
+        def values = User.withCriteria {
+            eq 'userId', userid
+            projections {
+                property(prop)
+            }
+        }
+
+        values.size() > 0 ? values[0] : 'unknown'
+    }
+
+    def idForUserProperty(String propertyName, String propertyValue) {
+        def values = User.withCriteria {
+            eq propertyName, propertyValue
+            projections {
+                property 'userId'
+            }
+        }
+        values.size() > 0 ? values[0] : ''
+    }
 }

--- a/grails-app/views/institutionAdmin/_form.gsp
+++ b/grails-app/views/institutionAdmin/_form.gsp
@@ -67,12 +67,14 @@
     <g:textField name="imageCaption" value="${institutionInstance?.imageCaption}"/>
 </div>
 
-<div class="fieldcontain ${hasErrors(bean: institutionInstance, field: 'collectoryUid', 'error')} ">
-    <label for="collectoryUid">
-        <g:message code="institution.collectoryUid.label" default="Collectory Uid" />
-    </label>
-    <g:textField class="input-mini" name="collectoryUid" value="${institutionInstance.collectoryUid}"/>
-</div>
+<g:if test="${institutionInstance.collectoryUid}">
+    <div class="fieldcontain ${hasErrors(bean: institutionInstance, field: 'collectoryUid', 'error')} ">
+        <label for="collectoryUid">
+            <g:message code="institution.collectoryUid.label" default="Collectory Uid" />
+        </label>
+        <g:textField class="input-mini" name="collectoryUid" value="${institutionInstance.collectoryUid}"/>
+    </div>
+</g:if>
 <r:script>
 jQuery(function($) {
     tinyMCE.init({

--- a/grails-app/views/task/showDetails.gsp
+++ b/grails-app/views/task/showDetails.gsp
@@ -108,7 +108,7 @@
                                     <td>Transcribed</td>
                                     <td>
                                         <g:if test="${taskInstance.dateFullyTranscribed}">
-                                            ${taskInstance.dateFullyTranscribed?.format("yyyy-MM-dd HH:mm:ss")} by ${taskInstance.fullyTranscribedBy ?: "<span class='muted'>unknown</span>"}
+                                            ${taskInstance.dateFullyTranscribed?.format("yyyy-MM-dd HH:mm:ss")} by ${cl.emailForUserId(id: taskInstance.fullyTranscribedBy) ?: "<span class='muted'>unknown</span>"}
                                         </g:if>
                                         <g:else>
                                             <span class="muted">
@@ -122,7 +122,7 @@
                                     <td>Validated</td>
                                     <td>
                                         <g:if test="${taskInstance.dateFullyValidated}">
-                                            ${taskInstance.dateFullyValidated?.format("yyyy-MM-dd HH:mm:ss")} by ${taskInstance.fullyValidatedBy ?: "<span class='muted'>unknown</span>"}
+                                            ${taskInstance.dateFullyValidated?.format("yyyy-MM-dd HH:mm:ss")} by ${cl.emailForUserId(id: taskInstance.fullyValidatedBy) ?: "<span class='muted'>unknown</span>"}
                                         </g:if>
                                         <g:else>
                                             <span class="muted">
@@ -161,7 +161,7 @@
                                     <td>
                                         <ul>
                                             <g:each in="${taskInstance.viewedTasks?.sort({ it.lastView })}" var="view">
-                                                <li>Viewed by ${view.userId} ${view.numberOfViews > 1 ? "(" + view.numberOfViews + " times) " : ""} on ${view.lastUpdated?.format("yyyy-MM-dd HH:mm:ss")})</li>
+                                                <li>Viewed by <cl:userDisplayString id="${view.userId}" /> ${view.numberOfViews > 1 ? "(" + view.numberOfViews + " times) " : ""} on ${view.lastUpdated?.format("yyyy-MM-dd HH:mm:ss")})</li>
                                             </g:each>
                                         </ul>
                                     </td>
@@ -210,8 +210,8 @@
                                         <td>${field.value}</td>
                                         <td>${field.created?.format("yyyy-MM-dd HH:mm:ss")}</td>
                                         <td>${field.updated?.format("yyyy-MM-dd HH:mm:ss")}</td>
-                                        <td>${field.transcribedByUserId}</td>
-                                        <td>${field.validatedByUserId}</td>
+                                        <td><cl:emailForUserId id="${field.transcribedByUserId}" /></td>
+                                        <td><cl:emailForUserId id="${field.validatedByUserId}" /></td>
                                     </tr>
                                 </g:each>
                             </tbody>

--- a/grails-app/views/template/create.gsp
+++ b/grails-app/views/template/create.gsp
@@ -31,15 +31,6 @@
 
                                 <tr class="prop">
                                     <td valign="top" class="name">
-                                        <label for="author"><g:message code="template.author.label" default="Author" /></label>
-                                    </td>
-                                    <td valign="top" class="value ${hasErrors(bean: templateInstance, field: 'author', 'errors')}">
-                                        <g:textField name="author" maxlength="200" value="${templateInstance?.author}" />
-                                    </td>
-                                </tr>
-
-                                <tr class="prop">
-                                    <td valign="top" class="name">
                                         <label for="name"><g:message code="template.name.label" default="Name" /></label>
                                     </td>
                                     <td valign="top" class="value ${hasErrors(bean: templateInstance, field: 'name', 'errors')}">

--- a/grails-app/views/template/edit.gsp
+++ b/grails-app/views/template/edit.gsp
@@ -56,15 +56,6 @@
 
                                 <tr class="prop">
                                     <td valign="top" class="name">
-                                      <label for="author"><g:message code="template.author.label" default="Author" /></label>
-                                    </td>
-                                    <td valign="top" class="value ${hasErrors(bean: templateInstance, field: 'author', 'errors')}">
-                                        <g:textField name="author" maxlength="200" value="${templateInstance?.author}" />
-                                    </td>
-                                </tr>
-
-                                <tr class="prop">
-                                    <td valign="top" class="name">
                                       <label for="name"><g:message code="template.name.label" default="Name" /></label>
                                     </td>
                                     <td valign="top" class="value ${hasErrors(bean: templateInstance, field: 'name', 'errors')}">

--- a/grails-app/views/template/list.gsp
+++ b/grails-app/views/template/list.gsp
@@ -74,7 +74,7 @@
                         <tr class="${(i % 2) == 0 ? 'odd' : 'even'}" templateId="${templateInstance.id}" templateName="${templateInstance.name}" >
 
                             <td>${fieldValue(bean: templateInstance, field: "name")}</td>
-                            <td>${fieldValue(bean: templateInstance, field: "author")}</td>
+                            <td>${cl.emailForUserId(id: templateInstance.author)}</td>
                             <td>${fieldValue(bean: templateInstance, field: "viewName")}</td>
 
                             <td>

--- a/grails-app/views/template/show.gsp
+++ b/grails-app/views/template/show.gsp
@@ -32,7 +32,7 @@
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="template.author.label" default="Author" /></td>
                             
-                            <td valign="top" class="value">${fieldValue(bean: templateInstance, field: "author")}</td>
+                            <td valign="top" class="value">${cl.emailForUserId(id: templateInstance.author)}</td>
                             
                         </tr>
                     

--- a/grails-app/views/user/edit.gsp
+++ b/grails-app/views/user/edit.gsp
@@ -8,10 +8,10 @@
     </head>
     <body>
 
-        <cl:headerContent crumbLabel="Volunteers" title="Edit User ${userInstance.userId}">
+        <cl:headerContent crumbLabel="Volunteers" title="Edit User ${userInstance.userId} - ${userDetails.displayName} (${userDetails.userName})">
             <%
                 pageScope.crumbs = []
-                pageScope.crumbs << [link: createLink(controller: 'user', action: 'show', id: userInstance.id), label: userInstance.displayName]
+                pageScope.crumbs << [link: createLink(controller: 'user', action: 'show', id: userInstance.id), label: userDetails.displayName]
             %>
         </cl:headerContent>
 
@@ -72,6 +72,15 @@
                                     </td>
                                     <td valign="top" class="value ${hasErrors(bean: userInstance, field: 'displayName', 'errors')}">
                                         <g:textField name="displayName" value="${userInstance?.displayName}" />
+                                    </td>
+                                </tr>
+
+                                <tr class="prop">
+                                    <td valign="top" class="name">
+                                        <label for="email"><g:message code="user.email.label" default="Email addresss" /></label>
+                                    </td>
+                                    <td valign="top" class="value ${hasErrors(bean: userInstance, field: 'email', 'errors')}">
+                                        <g:textField name="email" value="${userInstance?.email}" />
                                     </td>
                                 </tr>
 


### PR DESCRIPTION
Remove the option to set author on a template and do it automatically instead
Fix numeric ids displaying on the edit user page
Fix numeric ids displaying on the task admin showDetails page
