### PR TITLE
Performance upgrades

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/TranscribeController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TranscribeController.groovy
@@ -1,5 +1,6 @@
 package au.org.ala.volunteer
 
+import com.google.common.base.Stopwatch
 import org.apache.commons.lang.StringUtils
 
 class TranscribeController {
@@ -29,6 +30,8 @@ class TranscribeController {
     }
 
     def task() {
+
+        Stopwatch sw = Stopwatch.createStarted()
 
         def taskInstance = Task.get(params.int('id'))
         def currentUserId = userService.currentUserId
@@ -90,6 +93,7 @@ class TranscribeController {
                     complete: params.complete,
                     thumbnail: multimediaService.getImageThumbnailUrl(taskInstance.multimedia.first(), true)
             ]
+            log.debug('task before render: {}', sw)
             render(view: 'templateViews/' + project.template.viewName, model: model)
         } else {
             redirect(view: 'list', controller: "task")

--- a/grails-app/controllers/au/org/ala/volunteer/ValidateController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ValidateController.groovy
@@ -56,11 +56,10 @@ class ValidateController {
                 }
             }
 
-            Stopwatch sw = new Stopwatch()
-            sw.start()
+            Stopwatch sw = Stopwatch.createStarted()
             Map recordValues = fieldSyncService.retrieveValidationFieldsForTask(taskInstance)
             sw.stop()
-            println sw.elapsed(TimeUnit.SECONDS)
+            log.debug('retrieveValidationFieldsForTask: {}', sw.elapsed(TimeUnit.SECONDS))
             def adjacentTasks = taskService.getAdjacentTasksBySequence(taskInstance)
             def imageMetaData = taskService.getImageMetaData(taskInstance)
             def transcribersAnswers = fieldSyncService.retrieveTranscribersFieldsForTask(taskInstance)

--- a/grails-app/domain/au/org/ala/volunteer/Multimedia.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/Multimedia.groovy
@@ -14,6 +14,7 @@ class Multimedia implements Serializable {
   String creator
 
   static mapping = {
+    cache true
     version false
     task index: 'multimedia_task_idx'
   }

--- a/grails-app/domain/au/org/ala/volunteer/Project.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/Project.groovy
@@ -55,6 +55,8 @@ class Project implements Serializable {
     static transients = ['featuredImage', 'backgroundImage', 'grailsApplication', 'grailsLinkGenerator', 'requiredNumberOfTranscriptions']
 
     static mapping = {
+        cache true
+        tasks cache: true
         autoTimestamp true
         description sqlType: 'text'
         tasks cascade: 'all,delete-orphan'

--- a/grails-app/domain/au/org/ala/volunteer/Task.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/Task.groovy
@@ -28,6 +28,8 @@ class Task implements Serializable {
     static hasMany = [multimedia: Multimedia, viewedTasks: ViewedTask, fields: Field, comments: TaskComment, transcriptions: Transcription]
 
     static mapping = {
+        cache true
+        multimedia cache: true
         version false
         multimedia cascade: 'all,delete-orphan'
         viewedTasks cascade: 'all,delete-orphan'

--- a/grails-app/domain/au/org/ala/volunteer/Task.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/Task.groovy
@@ -133,7 +133,7 @@ class Task implements Serializable {
 
         Set taskFields = fields.findAll{it.transcription == null}
 
-        println taskFields
+        log.debug('taskfields {}', taskFields)
         taskFields
 
 

--- a/grails-app/services/au/org/ala/volunteer/MultimediaService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/MultimediaService.groovy
@@ -63,4 +63,20 @@ class MultimediaService {
     private String filenameFromFilePath(String filePath) {
         StringUtils.substringAfterLast(filePath, '/')
     }
+
+    Map<Long, Multimedia> findImagesForTasks(Collection<Long> taskIds) {
+        List<Multimedia> mm = []
+        if (taskIds) {
+            mm = Multimedia.withCriteria {
+                task {
+                    'in'('id', taskIds)
+                }
+            }
+        }
+        return mm.groupBy {
+            it.taskId
+        }.collectEntries { taskId, mms ->
+            [(taskId): mms?.find { it.mimeType.startsWith('image') }]
+        }
+    }
 }

--- a/grails-app/services/au/org/ala/volunteer/ProjectService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ProjectService.groovy
@@ -278,7 +278,7 @@ class ProjectService {
 
     }
 
-    public List<ProjectSummary> getFeaturedProjectList() {
+    public List<ProjectSummary>  getFeaturedProjectList() {
 
         Stopwatch sw = Stopwatch.createStarted()
         def resultMaps = generateProjectSummariesQuery(jooqContextFactory(), [], null, null, 'transcribed', null, null, null, ProjectStatusFilterType.showIncompleteOnly, ProjectActiveFilterType.showActiveOnly, false).fetchMaps()

--- a/grails-app/services/au/org/ala/volunteer/TaskService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/TaskService.groovy
@@ -397,7 +397,7 @@ class TaskService {
 
         if (tasks) {
             def task = tasks.last()
-            println "getNextTaskForValidationForProject(project ${project.id}) found a task: ${task.id}"
+            log.debug("getNextTaskForValidationForProject(project {}) found a task: {}", project.id, task.id)
             return task
         }
 
@@ -415,7 +415,7 @@ class TaskService {
 
         if (tasks) {
             def task = tasks.last()
-            log.debug("getNextTaskForValidationForProject(project ${project.id}) found a task: ${task.id}", project.id, task.id)
+            log.debug("getNextTaskForValidationForProject(project {}) found a task: {}", project.id, task.id)
             return task
         }
 

--- a/grails-app/taglib/au/org/ala/volunteer/TimingTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/TimingTagLib.groovy
@@ -1,0 +1,33 @@
+package au.org.ala.volunteer
+
+import com.google.common.base.Stopwatch
+import groovy.util.logging.Slf4j
+
+@Slf4j('logger')
+class TimingTagLib {
+    static defaultEncodeAs = [taglib:'none']
+    //static encodeAsForTags = [tagName: [taglib:'html'], otherTagName: [taglib:'none']]
+//    static returnObjectForTags = ['start', 'log']
+
+    static namespace = "time"
+
+    Stopwatch sw
+
+    def start = { attrs ->
+        sw = Stopwatch.createStarted()
+    }
+
+    def log = { attrs ->
+        def message = attrs.remove('message')
+        logger.debug("{}: {}", message, sw)
+        sw.reset().start()
+    }
+
+    def block = { attrs, body ->
+        def sw1 = Stopwatch.createStarted()
+        def message = attrs.remove('message')
+        out << body()
+        logger.debug('{}: {}', message, sw1)
+        return
+    }
+}

--- a/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
@@ -1,6 +1,7 @@
 package au.org.ala.volunteer
 
 import au.org.ala.cas.util.AuthenticationCookieUtils
+import com.google.common.base.Stopwatch
 import com.google.gson.GsonBuilder
 import grails.converters.JSON
 import grails.util.Environment
@@ -607,8 +608,10 @@ class VolunteerTagLib {
     }
 
     def multimediaThumbnail = { attrs, body ->
+        Stopwatch sw = Stopwatch.createStarted()
         def url, fullUrl = ''
-        def mm = attrs.task.multimedia?.first()
+//        def mm = attrs.task.multimedia?.first()
+        def mm = attrs.multimedia
         if (mm) {
             url = multimediaService.getImageThumbnailUrl(mm)
             fullUrl = multimediaService.getImageUrl(mm)
@@ -626,9 +629,11 @@ class VolunteerTagLib {
             out << "<img src=\"${url}\" data-full-src=\"$fullUrl\"/>"
             out << "<img class=\"hidden\" src=\"$fullUrl\"/>"
         }
+        log.debug('multimediaThumbnail {}', sw)
     }
 
     def taskThumbnail = { attrs, body ->
+        Stopwatch sw = Stopwatch.createStarted()
         def task = attrs.task as Task
         def fixedHeight = attrs.fixedHeight
         def withHidden = attrs.withHidden
@@ -658,6 +663,7 @@ class VolunteerTagLib {
             }
 
         }
+        log.debug('taskThumbnail {}', sw)
     }
 
     /**

--- a/grails-app/views/transcribe/_cameraTrapImageSequence.gsp
+++ b/grails-app/views/transcribe/_cameraTrapImageSequence.gsp
@@ -2,15 +2,15 @@
     <g:set var="tasks" value="${taskSequence(number: sequenceNumber, count: 3, task:taskInstance)}"/>
     <g:each in="${tasks.previous}" var="task">
         <div class="film-cell" data-seq-no="${task.sequenceNumber}">
-            <cl:multimediaThumbnail task="${task.task}" seqNo="${task.sequenceNumber}"/>
+            <cl:multimediaThumbnail multimedia="${task.multimedia}" seqNo="${task.sequenceNumber}"/>
         </div>
     </g:each>
     <div class="film-cell active default" data-seq-no="${sequenceNumber}">
-        <cl:taskThumbnail task="${taskInstance}" fixedHeight="${false}" withHidden="${true}"/>
+        <cl:multimediaThumbnail multimedia="${tasks.current.multimedia}" seqNo="${tasks.current.sequenceNumber}"/>
     </div>
     <g:each in="${tasks.next}" var="task">
         <div class="film-cell" data-seq-no="${task.sequenceNumber}">
-            <cl:multimediaThumbnail task="${task.task}" seqNo="${task.sequenceNumber}"/>
+            <cl:multimediaThumbnail multimedia="${task.multimedia}" seqNo="${task.sequenceNumber}"/>
         </div>
     </g:each>
 </div>

--- a/src/main/resources/digivol-ehcache.xml
+++ b/src/main/resources/digivol-ehcache.xml
@@ -339,4 +339,28 @@
             logging="true"
     >
     </cache>
+    <cache
+            name="getImageMetaData"
+            eternal="false"
+            timeToLiveSeconds="120"
+            maxElementsInMemory="1000"
+            maxElementsOnDisk="2000"
+            memoryStoreEvictionPolicy="LRU"
+            overflowToDisk="true"
+            diskPersistent="false"
+            diskExpiryThreadIntervalSeconds="120"
+    >
+    </cache>
+    <cache
+            name="getImageMetaDataFromFile"
+            eternal="false"
+            timeToLiveSeconds="300"
+            maxElementsInMemory="1000"
+            maxElementsOnDisk="2000"
+            memoryStoreEvictionPolicy="LRU"
+            overflowToDisk="true"
+            diskPersistent="false"
+            diskExpiryThreadIntervalSeconds="120"
+    >
+    </cache>
 </ehcache>


### PR DESCRIPTION
 - Update camera trap film strip to pull all required sequence task ids at once
 - Update camera trap film strip to pull all multimedia at once, avoiding loading tasks
 - Add cache TaskService.getImageMetaData as it is slow
 - Add TimingTagLib which allows easy timing of GSP write times
 - Add extra debug timing logs