### PR TITLE
DG-76, DG-16 Modifying Wildlife Spotter transcriptions and auto-validation threshold

### DIFF
--- a/grails-app/assets/javascripts/transcribe/wildlifespotter.js
+++ b/grails-app/assets/javascripts/transcribe/wildlifespotter.js
@@ -107,26 +107,10 @@ function wildlifespotter(wsParams, imagePrefix, recordValues, placeholders) {
       var templateObj = {
         selectedAnimals: _.chain(selectedIndicies).keys().map(function (v,i) {
 
-          // var curval = 0;
-          // if (!selectedIndicies[v].init) {
-          //   curval = selectedIndicies[v].count;
-          // } else {
-          //   selectedIndicies[v].count = 0;
-          //   selectedIndicies[v].init = false;
-          // }
-
           return {
             index: v,
             name: wsParams.animals[v].vernacularName,
             curval: selectedIndicies[v].count,
-            //curval: curval,
-            // options: _([1,2,3,4,5,6,7,8,9,10]).map(function(opt,i) {
-            //   return {
-            //     val: opt,
-            //     selected: selectedIndicies[v].count == opt ? 'selected' : '',
-            //     isSelected: selectedIndicies[v].count == opt ? 'true' : 'false'
-            //   };
-            // }),
             comment: selectedIndicies[v].comment
           };
 
@@ -154,7 +138,7 @@ function wildlifespotter(wsParams, imagePrefix, recordValues, placeholders) {
       var $this = $(this);
       var idx = $this.closest('[data-item-index]').data('item-index');
       var count = $this.val();
-      console.log("value change: " + count);
+      // console.log("value change: " + count);
       selectedIndicies[idx].count = parseInt(count);
       generateFormFields();
     });
@@ -176,12 +160,12 @@ function wildlifespotter(wsParams, imagePrefix, recordValues, placeholders) {
     $("#ct-container").on('keydown', '.numAnimals', function(e) {
       // Allow: backspace, delete, tab, escape, enter and .
       if ($.inArray(e.keyCode, [46, 8, 9, 27, 13, 110, 190]) !== -1 || (e.keyCode === 65 && e.ctrlKey === true) || (e.keyCode >= 35 && e.keyCode <= 40)) {
-        console.log("key " + e.keyCode + " allowed");
+        // console.log("key " + e.keyCode + " allowed");
         return;
       }
 
       if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
-        console.log("key " + e.keyCode + " not allowed");
+        // console.log("key " + e.keyCode + " not allowed");
         e.preventDefault();
       }
     });
@@ -401,7 +385,8 @@ function wildlifespotter(wsParams, imagePrefix, recordValues, placeholders) {
         mu.appendTemplate($ctFields, 'input-template', {id: 'recordValues.' + i + '.comment', value: value.comment});
         ++i;
       });
-      console.log("Enable submit button? " + enableSubmit);
+
+      // console.log("Enable submit button? " + enableSubmit);
       if (enableSubmit) $('#btnSave').removeAttr('disabled');
       else $('#btnSave').attr('disabled', 'disabled');
     }
@@ -431,8 +416,6 @@ function wildlifespotter(wsParams, imagePrefix, recordValues, placeholders) {
       });
     }
 
-
-
     transcribeValidation.addCustomValidator(function(errorList) {
       var q1 = $('input[name=recordValues\\.0\\.noAnimalsVisible]:checked').val();
       var q2 = $('input[name=recordValues\\.0\\.problemWithImage]:checked').val();
@@ -442,12 +425,10 @@ function wildlifespotter(wsParams, imagePrefix, recordValues, placeholders) {
         errorList.push({element: null, message: "You must either indicate that there are no animals, there's a problem with the image or select at least one animal before you can submit", type: "Error" });
       }
     });
-    transcribeValidation.setErrorRenderFunctions(function (errorList) {
-      },
-      function() {
-      });
 
-    submitRequiresConfirmation = true;
+    transcribeValidation.setErrorRenderFunctions(function (errorList) {}, function() {});
+    var submitRequiresConfirmation = true;
+
     postValidationFunction = function(validationResults) {
       if (validationResults.errorList.length > 0) bootbox.alert("<h3>Invalid selection</h3><ul><li>" + _.pluck(validationResults.errorList, 'message').join('</li><li>') + "</li>");
     };

--- a/grails-app/services/au/org/ala/volunteer/ValidationService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ValidationService.groovy
@@ -128,7 +128,13 @@ class ValidationService {
      */
     private boolean fieldsMatch(Transcription t1, Transcription t2) {
         if (t1?.project?.projectType?.name == ProjectType.PROJECT_TYPE_CAMERATRAP) {
-            return fieldsMatch(t1, t2, CAMERATRAP_EXCLUDED_FIELDS)
+            // If validation type is set to species only, add individual count to the list of excluded fields
+            def ctExcludedFields = CAMERATRAP_EXCLUDED_FIELDS
+            def viewParams = t1?.project?.template?.viewParams
+            if (viewParams && AutoValidationType.fromString(viewParams?.autoValidationType as String) == AutoValidationType.speciesOnly) {
+                ctExcludedFields.add(DarwinCoreField.individualCount.name())
+            }
+            return fieldsMatch(t1, t2, ctExcludedFields)
         } else {
             return fieldsMatch(t1, t2, EXCLUDED_FIELDS)
         }

--- a/grails-app/views/template/_wildlifespotterTranscribeParams.gsp
+++ b/grails-app/views/template/_wildlifespotterTranscribeParams.gsp
@@ -1,46 +1,65 @@
+<%@ page import="au.org.ala.volunteer.AutoValidationType" %>
 <div class="form-group">
-    <div class="col-md-offset-3 col-md-6">
+    <label class="col-md-3 control-label" for="exportGroupByIndex">
+        <g:message code="template.hideDefaultButtons.label" default="Hide Default Buttons"/>
+    </label>
+    <div class="col-md-6">
         <div class="checkbox">
-            <label>
-                <g:checkBox name="hideDefaultButtons" data-default="true"/>
-                <g:message code="template.hideDefaultButtons.label" default="Hide Default Buttons"/>
-            </label>
+            <g:checkBox name="hideDefaultButtons" data-default="true"/>
         </div>
     </div>
 </div>
 
 <div class="form-group">
-    <div class="col-md-offset-3 col-md-6">
+    <label class="col-md-3 control-label" for="exportGroupByIndex">
+        <g:message code="template.hideSectionNumbers.label" default="Hide Section Numbers"/>
+    </label>
+    <div class="col-md-6">
         <div class="checkbox">
-            <label>
-                <g:checkBox name="hideSectionNumbers" data-default="true"/>
-                <g:message code="template.hideSectionNumbers.label" default="Hide Section Numbers"/>
-            </label>
+            <g:checkBox name="hideSectionNumbers" data-default="true"/>
         </div>
     </div>
 </div>
 
 <div class="form-group">
-    <div class="col-md-offset-3 col-md-6">
+    <label class="col-md-3 control-label" for="exportGroupByIndex">
+        <g:message code="template.exportGroupByIndex.label" default="Group fields by index in CSV export"/>
+    </label>
+    <div class="col-md-6" style="padding-bottom: 10px;">
         <div class="checkbox">
-            <label>
                 <g:checkBox name="exportGroupByIndex" data-default="true"/>
-                <g:message code="template.exportGroupByIndex.label" default="Group fields by index in CSV export"/>
-            </label>
         </div>
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-md-3 control-label" for="jumpNTasks"><g:message code="template.wildlifeSpotter.jump.label"
-                                                             default="Number of tasks to jump on save / skip"/></label>
+    <label class="col-md-3 control-label" for="autoValidationType">
+        <g:message code="template.autoValidationType.label" default="System Validation Type"/>
+        &nbsp;&nbsp;<a href="#" class="btn btn-default btn-xs fieldHelp"
+                       title="<g:message code="template.autoValidationType.helptext"
+                                         default="Select the field combination that the System will use for comparison when auto-validating."/>">
+        <span class="help-container"><i class="fa fa-question"></i></span></a>
+    </label>
+    <div class="col-md-6">
+        <g:select class="form-control"
+                  name="autoValidationType"
+                  from="${AutoValidationType.values()}"
+                  optionValue="label"
+                  value="${AutoValidationType.getDefault()}" />
+    </div>
+</div>
 
+<div class="form-group">
+    <label class="col-md-3 control-label" for="jumpNTasks">
+        <g:message code="template.wildlifeSpotter.jump.label" default="Number of tasks to jump on save / skip"/>
+    </label>
     <div class="col-md-6">
         <g:field type="number" name="jumpNTasks" min="1" max="10" data-default="6" class="form-control"/>
     </div>
 </div>
+
 <div class="form-group">
-    <div class="col-sm-offset-3 col-sm-9">
+    <div class="col-md-offset-3 col-md-9" style="padding-bottom: 5px;">
         <g:link class="btn btn-primary" controller="template" action="wildlifeTemplateConfig" id="${templateInstance.id}">Configure Wildlife Spotter Entries</g:link>
     </div>
 </div>

--- a/grails-app/views/template/edit.gsp
+++ b/grails-app/views/template/edit.gsp
@@ -5,6 +5,11 @@
     <meta name="layout" content="${grailsApplication.config.getProperty('ala.skin', String)}"/>
     <g:set var="entityName" value="${message(code: 'template.label', default: 'Template')}"/>
     <title><g:message code="default.edit.label" args="[entityName]"/></title>
+    <style>
+        input[type="checkbox"] {
+            margin-left: 0px !important;
+        }
+    </style>
 </head>
 
 <body class="admin">
@@ -58,7 +63,6 @@
                         </div>
 
                         <div id="row-view-params-form" style="display: none;">
-
                         </div>
 
                         <div id="row-view-params-json"
@@ -73,68 +77,58 @@
                         </div>
 
                         <div class="form-group ${hasErrors(bean: templateInstance, field: 'supportMultipleTranscriptions', 'has-error')}">
-                            <label class="col-md-4 control-label" for="supportMultipleTranscriptions">
+                            <label class="col-md-3 control-label" for="supportMultipleTranscriptions">
                                 <g:message code="template.multipletanscriptions.label"
-                                           default="Support multiple transcriptions per task?"/>&nbsp;&nbsp;<a href="#" class="btn btn-default btn-xs fieldHelp"
-                                                                                                   title="<g:message code="template.multipletanscriptions.helptext"
-                                                                                                                     default="Ignored for Specimen and Fieldnote Expedition types."/>"><span
-                                        class="help-container"><i class="fa fa-question"></i> </span></a>
+                                           default="Support multiple transcriptions per task?"/>
+
                             </label>
                             <div class="col-md-6">
                                 <div style="padding-top: 10px">
-                                <g:checkBox name="supportMultipleTranscriptions"
-                                            checked="${templateInstance.supportMultipleTranscriptions}"/>
+                                    <g:checkBox name="supportMultipleTranscriptions"
+                                                checked="${templateInstance.supportMultipleTranscriptions}"/>
+                                    &nbsp;&nbsp;<a href="#" class="btn btn-default btn-xs fieldHelp"
+                                                   title="<g:message code="template.multipletanscriptions.helptext"
+                                                                     default="Ignored for Specimen and Fieldnote Expedition types."/>">
+                                    <span class="help-container"><i class="fa fa-question"></i></span></a>
                                 </div>
                             </div>
                         </div>
 
                         <cl:ifSiteAdmin>
-                            <div class="form-group ${hasErrors(bean: templateInstance, field: 'isGlobal', 'has-error')}">
-                                <label class="col-md-4 control-label" for="isGlobal">
-                                    <g:message code="template.isglobal.label"
-                                               default="Is a Global Template (available to everyone)?"/>
-                                </label>
-                                <div class="col-md-6">
-                                    <div style="padding-top: 10px">
-                                        <g:checkBox name="isGlobal"
-                                                    checked="${templateInstance.isGlobal}"/>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="form-group ${hasErrors(bean: templateInstance, field: 'isHidden', 'has-error')}">
-                                <label class="col-md-4 control-label" for="isHidden">
-                                    <g:message code="template.ishidden.label"
-                                               default="Hide Template (hide from all editors)?"/>
-                                </label>
-                                <div class="col-md-6">
-                                    <div style="padding-top: 10px">
-                                        <g:checkBox name="isHidden"
-                                                    checked="${templateInstance.isHidden}"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </cl:ifSiteAdmin>
-
-                        <div id="row-view-params-json" class="form-group">
-                            <label class="col-md-4 control-label"><g:message code="template.project.label"
-                                                                                  default="Projects that use this template:"/></label>
-
+                        <div class="form-group ${hasErrors(bean: templateInstance, field: 'isGlobal', 'has-error')}">
+                            <label class="col-md-3 control-label" for="isGlobal">
+                                <g:message code="template.isglobal.label"
+                                           default="Is a Global Template?"/>
+                            </label>
                             <div class="col-md-6">
-                                <g:each in="${projectUsageList}" var="project">
-                                    <ul>
-                                        <li class="form-control-static">${(project.key ? project.key : "No institution")}</li>
-                                        <ul>
-                                            <g:each in="${project.value}" var="proj">
-                                                <li><g:link controller="project" action="show" id="${proj.id}">${proj.name}</g:link></li>
-                                            </g:each>
-                                        </ul>
-                                    </ul>
-                                </g:each>
+                                <div style="padding-top: 10px">
+                                    <g:checkBox name="isGlobal"
+                                                checked="${templateInstance.isGlobal}"/>
+                                    &nbsp;&nbsp;<a href="#" class="btn btn-default btn-xs fieldHelp"
+                                                   title="<g:message code="template.globaltemplate.helptext"
+                                                                     default="A global template is available to all institutions."/>">
+                                    <span class="help-container"><i class="fa fa-question"></i></span></a>
+                                </div>
                             </div>
                         </div>
 
+                        <div class="form-group ${hasErrors(bean: templateInstance, field: 'isHidden', 'has-error')}">
+                            <label class="col-md-3 control-label" for="isHidden">
+                                <g:message code="template.ishidden.label"
+                                           default="Hide Template?"/>
+                            </label>
+                            <div class="col-md-6">
+                                <div style="padding-top: 10px">
+                                    <g:checkBox name="isHidden"
+                                                checked="${templateInstance.isHidden}"/>
+                                    &nbsp;&nbsp;<a href="#" class="btn btn-default btn-xs fieldHelp"
+                                                   title="<g:message code="template.hidden.helptext"
+                                                                     default="Hide this template from all users."/>">
+                                    <span class="help-container"><i class="fa fa-question"></i></span></a>
+                                </div>
+                            </div>
                         </div>
+                        </cl:ifSiteAdmin>
 
                         <div class="form-group">
                             <div class="col-md-offset-3 col-md-9">
@@ -149,11 +143,31 @@
                             </div>
                         </div>
                     </g:form>
+
+                    <div id="row-view-params-json" class="form-group">
+                        <label class="col-md-3 control-label">
+                            <g:message code="template.project.label"
+                                       default="Projects that use this template:"/>
+                        </label>
+                        <div class="col-md-6">
+                            <g:each in="${projectUsageList}" var="project">
+                                <ul>
+                                    <li class="form-control-static">${(project.key ? project.key : "No institution")}</li>
+                                    <ul>
+                                        <g:each in="${project.value}" var="proj">
+                                            <li><g:link controller="project" action="show" id="${proj.id}">${proj.name}</g:link></li>
+                                        </g:each>
+                                    </ul>
+                                </ul>
+                            </g:each>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
 <asset:javascript src="underscore" asset-defer=""/>
 <asset:javascript src="qtip" asset-defer=""/>
 <asset:script type="text/javascript">
@@ -246,6 +260,7 @@
             p.done(function(data, textStatus, jqXHR) {
                 $('#row-view-params-form').css('display', 'initial').html(data);
                 addDefaults();
+                updateHelpTips();
                 syncParamsFields();
             });
 
@@ -254,20 +269,22 @@
             });
         }).change();
 
-        // Context sensitive help popups
-        $("a.fieldHelp").each(function() {
-        var self = this;
-            $(self).qtip({
-                content: $(self).attr('title'),
-                position: {
-                    at: "top left",
-                    my: "bottom right"
-                },
-                style: {
-                    classes: 'qtip-bootstrap'
-                }
-            }).bind('click', function(e) { e.preventDefault(); return false; });
-        });
+        function updateHelpTips() {
+            // Context sensitive help popups
+            $("a.fieldHelp").each(function() {
+                var self = this;
+                $(self).qtip({
+                    content: $(self).attr('title'),
+                    position: {
+                        at: "top left",
+                        my: "bottom right"
+                    },
+                    style: {
+                        classes: 'qtip-bootstrap'
+                    }
+                }).bind('click', function(e) { e.preventDefault(); return false; });
+            });
+        }
 
     });
 

--- a/grails-app/views/transcribe/_wildlifeSpotterWidget.gsp
+++ b/grails-app/views/transcribe/_wildlifeSpotterWidget.gsp
@@ -1,23 +1,32 @@
 <div class="itemgrid">%{--
     display: inline-block, so no spaces between the divs
-    --}%<g:each in="${imageInfos}" var="piItem" status="st"><div class="griditem bvpBadge"
-                                                                           data-item-index="${st}">
-        <g:if test="${piItem?.audio?.size() > 0}">
-            <div class="thumbnail ct-thumbnail <g:if test="${!isAnswers}">ws-selector</g:if>" aria-selected="false" data-image-select-key="${st}" title="${g.message(code: 'audiotranscribe.widget.badge.title', args: [piItem.vernacularName])}">
-        </g:if>
-        <g:else>
-            <div class="thumbnail ct-thumbnail <g:if test="${!isAnswers}">ws-selector</g:if>" aria-selected="false" data-image-select-key="${st}" title="${g.message(code: 'wildlifespotter.widget.badge.title', args: [piItem.vernacularName])}">
-        </g:else>
-                <g:if test="${!isAnswers}">
-                    %{-- If Audio --}%
-                    <g:if test="${piItem?.audio?.size() > 0}">
-                        <g:set var="audioSample" value="${piItem.audio[0]}" />
-                        <cl:audioSample prefix="audiotranscribe" name="${audioSample.hash}" format="${audioSample.ext}"/>
-                    </g:if>
-                    <span class="ws-selected"><i class="fa fa-check"></i></span>
-                    <span class="ws-info" data-container="body"><i class="fa fa-info-circle"></i></span>
+    --}%
+<g:each in="${imageInfos}" var="piItem" status="st">
+    <div class="griditem bvpBadge" data-item-index="${st}">
+    <g:if test="${piItem?.audio?.size() > 0}">
+        <div class="thumbnail ct-thumbnail <g:if test="${!isAnswers}">ws-selector</g:if>"
+             aria-selected="false"
+             data-image-select-key="${st}"
+             data-validation-type="${viewParams.autoValidationType}"
+             title="${g.message(code: 'audiotranscribe.widget.badge.title', args: [piItem.vernacularName])}">
+    </g:if>
+    <g:else>
+        <div class="thumbnail ct-thumbnail <g:if test="${!isAnswers}">ws-selector</g:if>"
+             aria-selected="false"
+             data-image-select-key="${st}"
+             data-validation-type="${viewParams.autoValidationType}"
+             title="${g.message(code: 'wildlifespotter.widget.badge.title', args: [piItem.vernacularName])}">
+    </g:else>
+            <g:if test="${!isAnswers}">
+                %{-- If Audio --}%
+                <g:if test="${piItem?.audio?.size() > 0}">
+                    <g:set var="audioSample" value="${piItem.audio[0]}" />
+                    <cl:audioSample prefix="audiotranscribe" name="${audioSample.hash}" format="${audioSample.ext}"/>
                 </g:if>
-            %{--</g:if>--}%
+                <span class="ws-selected"><i class="fa fa-check"></i></span>
+                <span class="ws-info" data-container="body"><i class="fa fa-info-circle"></i></span>
+            </g:if>
+                %{--</g:if>--}%
             <div class="bvpBadgeMain cycler">
                 <g:each in="${piItem.images}" var="key" status="j">
                     <cl:sizedImage class="ct-thumbnail-image ws-thumbnail-image${j == 0 ? ' active' : ' '}"
@@ -32,5 +41,6 @@
                 </div>
             </div>
         </div>
-    </div></g:each>
+    </div>
+</g:each>
 </div>

--- a/grails-app/views/transcribe/templateViews/wildlifespotterTranscribe.gsp
+++ b/grails-app/views/transcribe/templateViews/wildlifespotterTranscribe.gsp
@@ -1,4 +1,4 @@
-<%@ page import="au.org.ala.volunteer.Picklist; au.org.ala.volunteer.FieldCategory; au.org.ala.volunteer.TemplateField; au.org.ala.volunteer.DarwinCoreField" %>
+<%@ page import="au.org.ala.volunteer.AutoValidationType; au.org.ala.volunteer.Picklist; au.org.ala.volunteer.FieldCategory; au.org.ala.volunteer.TemplateField; au.org.ala.volunteer.DarwinCoreField" %>
 <sitemesh:parameter name="useFluidLayout" value="${true}"/>
 <g:applyLayout name="digivol-task" model="${pageScope.variables}">
     <head>
@@ -9,6 +9,8 @@
         <div id="ct-container" >
 
             <g:set var="wsParams" value="${template.viewParams2}" />
+            <g:set var="viewParams" value="${template.viewParams}" />
+
             <div class="row">
                 <div id="ct-image-span" class="col-sm-6">
                     <div id="ct-image-well" class="panel panel-default">
@@ -117,7 +119,7 @@
                                             <g:set var="animalInfos"
                                                    value="${wsParams.animals}"/>
                                             <g:render template="/transcribe/wildlifeSpotterWidget"
-                                                      model="${[imageInfos: animalInfos]}"/>
+                                                      model="${[imageInfos: animalInfos, viewParams: viewParams]}"/>
                                         </div>
                                     </div>
                                 </div>
@@ -220,29 +222,57 @@
         </div>
 
         <script id="status-detail-list-template" type="text/x-mustache-template">
-            <ul class="status_detail_list">
+            <table class="table table-condensed">
+                <tr style="border-top: 0;">
+                    <th class="col-md-8" style="border-top: 0;">Species Name</th>
+                <g:if test="${AutoValidationType.fromString(viewParams.autoValidationType as String) == AutoValidationType.speciesWithCount}">
+                    <th class="col-md-2" style="border-top: 0;">Animal Count</th>
+                </g:if>
+                    <th class="col-md-2" style="border-top: 0;">Actions</th>
+                </tr>
                 {{#selectedAnimals}}
-                <li data-item-index="{{index}}">
-                    <div>
-                        <div class="classificationRow">
-                            <div class="animalName">{{name}}</div>
-                            <button type="button" class="btn btn-mini btn-default animalDelete pull-right" tabindex="-1"><i aria-hidden="true" class="fa fa-close"></i><span class="sr-only">Delete selection</span></button>
-                            <span class="animalNum pull-right">
-                                <select tabindex="-1" name="numAnimals" class="numAnimals form-control">
-                                    {{#options}}
-                                    <option value="{{val}}" {{selected}}>{{val}}</option>
-                                    {{/options}}
-                                </select>
-                            </span>
-                            <button type="button" aria-expanded="false" class="btn btn-link saveCommentButton pull-right" tabindex="-1" style="display:none;">Save Comment</button>
-                            <button type="button" aria-expanded="false" class="btn btn-link editCommentButton pull-right" tabindex="-1">Add Comment</button>
-                        </div>
+                <tr data-item-index="{{index}}">
+                    <td class="classificationRow col-md-8" style="border-top: 0;">
+                        <div class="animalName">{{name}}</div>
                         <div class="classificationComments">{{comment}}</div>
-                        <div class="editClassificationComments" style="display: none;"><label class="sr-only">Comment on the {{name}} you found</label><textarea id="{{index}}-comment" class="form-control" rows="1">{{comment}}</textarea></div>
-                    </div>
-                </li>
+                        <div class="editClassificationComments" style="display: none;">
+                            <label class="sr-only">Comment on the {{name}} you found</label>
+                            <textarea id="{{index}}-comment" class="form-control" rows="1">{{comment}}</textarea>
+                            <button type="button" aria-expanded="false" class="btn btn-default saveCommentButton pull-right" tabindex="-1" style="display:none;">Save</button>
+                        </div>
+                        <g:if test="${AutoValidationType.fromString(viewParams.autoValidationType as String) == AutoValidationType.speciesOnly}">
+                            <input type="hidden" name="numAnimals" data-validate-type="speciesOnly" data-default="{{curval}}" value="{{curval}}">
+                        </g:if>
+                    </td>
+                    <g:if test="${AutoValidationType.fromString(viewParams.autoValidationType as String) == AutoValidationType.speciesWithCount}">
+                    <td class="col-md-2" style="border-top: 0;">
+                        <span class="animalNum" style="padding-top: 5px; padding-right: 10px;">
+                            <input type="number"
+                                   name="numAnimals"
+                                   min="0" max="100"
+                                   data-default="{{curval}}"
+                                   data-validate-type="speciesWithCount"
+                                   value="{{curval}}"
+                                   class="form-control numAnimals"
+                                   tabindex="-1"/>
+                        </span>
+                    </td>
+                    </g:if>
+                    <td class="col-md-2" style="border-top: 0;">
+                        <button type="button"
+                                class="btn btn-default btn-xs editCommentButton"
+                                title="Add a comment">
+                            <i class="fa fa-commenting" tabindex="-1"></i>
+                            <span class="sr-only">Add a comment</span>
+                        </button>
+                        <button type="button" class="btn btn-xs btn-default animalDelete" title="Delete selection" tabindex="-1">
+                            <i aria-hidden="true" class="fa fa-trash"></i>
+                            <span class="sr-only">Delete selection</span>
+                        </button>
+                    </td>
+                </tr>
                 {{/selectedAnimals}}
-            </ul>
+            </table>
         </script>
 
         <script id="input-template" type="text/x-mustache-template">
@@ -252,7 +282,13 @@
         <script id="detail-template" type="text/x-mustache-template">
             <div class="detail-animal" >
                 <div id="ct-full-image-carousel" data-interval="0" class="carousel slide" data-item-index="{{itemIndex}}">
-                    <span class="ws-selector ws-selected ws-selected-large {{animal.selected}}" data-container="body" aria-selected="{{animal.isSelected}}" title="${g.message(code: 'wildlifespotter.widget.badge.title', args: ['{{animal.vernacularName}}'])}"><i class="fa fa-check"></i></span>
+                    <span class="ws-selector ws-selected ws-selected-large {{animal.selected}}"
+                          data-container="body"
+                          aria-selected="{{animal.isSelected}}"
+                          data-validation-type="${viewParams.autoValidationType}"
+                          title="${g.message(code: 'wildlifespotter.widget.badge.title', args: ['{{animal.vernacularName}}'])}">
+                        <i class="fa fa-check"></i>
+                    </span>
                     <span class="ws-full-image-carousel-close">&times;</span>
                     <ol class="carousel-indicators">
                         {{#animal.images}}
@@ -263,7 +299,6 @@
                         {{#animal.images}}
                         <div class="item {{active}}">
                             <cl:sizedImage prefix="wildlifespotter" name="{{hash}}" width="804" height="550" format="jpg" alt="{{animal.vernacularName}}" template="true"/>
-                            %{--<img src="{{url}}" />--}%
                         </div>
                         {{/animal.images}}
                     </div>

--- a/src/main/groovy/au/org/ala/volunteer/AutoValidationType.groovy
+++ b/src/main/groovy/au/org/ala/volunteer/AutoValidationType.groovy
@@ -1,0 +1,36 @@
+package au.org.ala.volunteer
+
+/**
+ * AutoValidationType is a set of allowed options when system validating wildlife spotter expeditions.
+ */
+enum AutoValidationType {
+    speciesOnly("Validate on Species only"),
+    speciesWithCount("Validate on Species and count")
+
+    def label
+
+    AutoValidationType(String label) {
+        this.label = label
+    }
+
+    /**
+     * Returns the default validation type.
+     * @return the default validation type.
+     */
+    static AutoValidationType getDefault() {
+        speciesWithCount
+    }
+
+    /**
+     * Translates an enum object from the string value. Returns the correlating validation type.
+     * @param validationType the validation type in string form.
+     * @return the validation type or default if not known.
+     */
+    static AutoValidationType fromString(String validationType) {
+        if (validationType) {
+            validationType as AutoValidationType
+        } else {
+            getDefault()
+        }
+    }
+}


### PR DESCRIPTION
- Implemented template-level setting to ignore animal count
- Updated UX for WS project transcriptions
-- Hide animal count when not required (from template setting)
-- Initialise count at zero
-- Use Bootstrap number field with built-in +/- controls
-- Disable save button until all selected animals count > 0
- Cleaned up unnecessary/commented out code