### PR TITLE
DG-117 Add export button to manage expedition admin page

### DIFF
--- a/grails-app/views/project/manage.gsp
+++ b/grails-app/views/project/manage.gsp
@@ -185,9 +185,7 @@
 
                                 <td style="white-space: nowrap;">
                                     <!-- Toggle Status -->
-%{--                                    <g:form name="activationForm_${projectInstance.project.id}" id="${projectInstance.project.id}" controller="project" action="update" params="${params}">--}%
                                     <g:if test="${projectInstance.project.inactive}">
-%{--                                        <g:hiddenField name="inactive" value="true"/>--}%
                                         <g:if test="${projectInstance.project.archived}">
                                             <button role="button" class="btn btn-default btn-xs"
                                                     title="You cannot activate an archived expedition." disabled><i class="fa fa-toggle-off"></i></button>
@@ -197,7 +195,6 @@
                                         </g:else>
                                     </g:if>
                                     <g:else>
-%{--                                        <g:hiddenField name="inactive" value="false"/>--}%
                                         <a class="btn btn-xs btn-default toggle-project-status" alt="Deactivate" title="Deactivate Expedition"><i class="fa fa-toggle-on"></i></a>
                                     </g:else>
 

--- a/grails-app/views/project/manage.gsp
+++ b/grails-app/views/project/manage.gsp
@@ -201,6 +201,8 @@
                                         <a class="btn btn-xs btn-default toggle-project-status" alt="Deactivate" title="Deactivate Expedition"><i class="fa fa-toggle-on"></i></a>
                                     </g:else>
 
+                                    <!-- Export -->
+                                    <a class="btn btn-xs btn-default export-project" alt="Export" title="Export Expedition (all tasks)"><i class="fa fa-table"></i></a>
 
                                     <!-- Clone -->
                                     <a class="btn btn-xs btn-default clone-project" alt="Clone" title="Clone Expedition"><i class="fa fa-clone"></i></a>
@@ -262,6 +264,16 @@ jQuery(function($) {
             $form.submit();
         }
     });
+
+    $(".export-project").click(function(e) {
+            e.preventDefault();
+            var projectId = $(this).parents("[projectId]").attr("projectId");
+            var options = {
+                title:'Export all tasks',
+                url:"${createLink(controller: "task", action: "exportOptionsFragment", params: [exportCriteria: 'all']).encodeAsJavaScript()}&projectId=" + projectId
+            };
+            bvp.showModal(options);
+        });
 
     $(".clone-project").click(function(e) {
         e.preventDefault();

--- a/grails-app/views/task/exportOptionsFragment.gsp
+++ b/grails-app/views/task/exportOptionsFragment.gsp
@@ -1,20 +1,27 @@
 <div class="row">
     <div class="col-md-12">
-        <h3>Select an export format</h3>
+        <strong>Select an export format</strong>
 
         <div class="input-group">
             <label class="radio" style="margin-left: 20px;">
                 <input type="radio" name="optionsExport" id="optionsExportCSV" value="csv" checked>
                 <strong>Single de-normalised CSV file</strong>
-                <br/>
-                Repeating fields will get a column each with a record index suffix (e.g. recordedBy_0, recordedBy_1). This is probably the most appropriate choice for specimen label transcriptions.
             </label>
+            <p>
+                Export will be a single CSV file. Repeating fields will have their own column each with a record index
+                suffix (e.g. recordedBy_0, recordedBy_1).
+                This is probably the most appropriate choice for <b>specimen label</b> transcriptions.
+            </p>
+
             <label class="radio" style="margin-left: 20px;">
                 <input type="radio" name="optionsExport" id="optionsExportZip" value="zip">
                 <strong>ZIP file</strong>
-                <br/>
-                A compressed archive of multiple flat CSV files, one for each one-to-many relationship. Files are linked by a task id. Suitable for field diaries and notebooks with large numbers of repeating fields.
             </label>
+            <p>
+                A compressed archive of multiple flat CSV files, one for each one-to-many relationship. Files are linked
+                by a task id. This would be most suitable for <b>field diaries</b> and <b>notebooks</b> with large
+                numbers of repeating fields.
+            </p>
         </div>
 
         <div class="input-group">


### PR DESCRIPTION
- Added button to Admin/Manage Expeditions to export (all tasks) for an expedition. 
- Should load the same functionality from the expedition home page menu button (display a dialog with 2 radio buttons to choose export format)