### PR TITLE
DG-49 Updated project map display to show ID and link to task

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/TaskController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TaskController.groovy
@@ -174,6 +174,8 @@ class TaskController {
         def jsonObj = [:]
         jsonObj.put("cat", recordValues?.get(0)?.catalogNumber)
         jsonObj.put("name", recordValues?.get(0)?.scientificName)
+        jsonObj.put("id", taskInstance.id)
+        jsonObj.put("filename", taskInstance.externalIdentifier)
 
         List transcribers = []
         taskInstance.transcriptions.each {

--- a/grails-app/views/project/index.gsp
+++ b/grails-app/views/project/index.gsp
@@ -277,7 +277,14 @@
 
                 url: "${createLink(controller: 'task', action: 'details')}/" + id,
                 success: function (data) {
-                    var content = "<div style='font-size:12px;line-height:1.3em;'>Catalogue No.: " + data.cat + "<br/>Taxon: " + data.name + "<br/>Transcribed by: " + data.transcriber + "</div>";
+                    var content = "<div style='font-size:12px;line-height:1.3em;'>Task: " + data.id + "<br/>";
+                <cl:ifValidator project="${projectInstance}">
+                    content += "File: <a href=\"${createLink(controller: 'task', action: 'showDetails')}/" + id + "\" target=\"_blank\">" + data.filename + "</a><br/>";
+                </cl:ifValidator>
+                <cl:ifNotValidator project="${projectInstance}">
+                    content += "File: " + data.filename + "<br/>";
+                </cl:ifNotValidator>
+                    content += "Transcribed by: " + data.transcriber + "</div>";
                     infowindow.close();
                     infowindow.setContent(content);
                     infowindow.open(map, marker);


### PR DESCRIPTION
Updated project map to display task ID, external file name and a link to the task if validator or higher role (Institution Admin or Site Admin).

Only displays pins on projects that utilise fields decimalLatitude and decimalLongitude. 
e.g. https://digivol-test.ala.org.au/project/index/2998922