### PR TITLE
Let ExportService date format check allow lower-precision dates/intervals

### DIFF
--- a/grails-app/services/au/org/ala/volunteer/ExportService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ExportService.groovy
@@ -653,7 +653,7 @@ class ExportService {
             // Check Event Date's validity
             jsonMapValues["dwc:Event"].verbatimEventDate = jsonMapValues["dwc:Event"].eventDate
             // Check if the date parses for an ISO 8601 format. If not, wipe the eventDate field (as it's invalid).
-            if (jsonMapValues["dwc:Event"].eventDate ==~ /^\d{4}(?:-\d{1,2}(?:-\d{1,2})?)$/) {
+            if (jsonMapValues["dwc:Event"].eventDate ==~ /^\d{4}(?:-\d{1,2}(?:-\d{1,2})?)?(?:\/\d{4}(?:-\d{1,2}(?:-\d{1,2})?)?)?$/) {
                 log.debug("Regex parse true: ${jsonMapValues["dwc:Event"].eventDate}")
             } else {
                 log.debug("Regex parse false ${jsonMapValues["dwc:Event"].eventDate}")


### PR DESCRIPTION
The non-capturing groups in this regex should've been optional to allow for single dates and/or date ranges with only a year or year-month component. As written it was only letting a value be included in the eventDate field if the format was exactly YYYY-MM-DD/YYYY-MM-DD.

Using optional groups allows strings like "2001/2002", "1967-10", "1999-03-04" to be sent in the eventDate field.