### PR TITLE
Bump webdriver plugin 2.6 > 3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "com.github.erdi:webdriver-binaries-gradle-plugin:3.2"
         classpath "org.grails.plugins:hibernate5:7.3.0" // This is different to gorm version
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
         classpath "org.postgresql:postgresql:$postgresVersion" // for flyway
@@ -22,6 +21,7 @@ plugins {
     id "com.virgo47.ClasspathJar" version "1.0.0"
     id 'java'
     id "com.dorongold.task-tree" version "2.1.1"
+    id "com.github.erdi.webdriver-binaries" version "3.2"
 }
 
 version "6.1.9-SNAPSHOT"
@@ -35,7 +35,6 @@ apply plugin:"eclipse"
 apply plugin:"idea"
 apply plugin:"war"
 apply plugin:"org.grails.grails-web"
-apply plugin:"com.github.erdi.webdriver-binaries"
 apply plugin:"com.bertramlabs.asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 apply plugin:"maven-publish"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.6"
+        classpath "com.github.erdi:webdriver-binaries-gradle-plugin:3.2"
         classpath "org.grails.plugins:hibernate5:7.3.0" // This is different to gorm version
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
         classpath "org.postgresql:postgresql:$postgresVersion" // for flyway
@@ -285,10 +285,10 @@ tasks.withType(GroovyCompile) {
 webdriverBinaries {
     if (!System.getenv().containsKey('GITHUB_ACTIONS')) {
         chromedriver {
-            version = '2.45.0'
+            version = '122.0.6260.0'
             fallbackTo32Bit = true
         }
-        geckodriver '0.30.0'
+        geckodriver '0.33.0'
     }
 }
 


### PR DESCRIPTION
Version 3.0 updated the host architecture code to handle non-x86 machines better, this allows tests to run on aarch64 machines without having to define a custom webdriver repository file.

Also updated the way the plugin is applied to move from the legacy API to the current plugin DSL (in a separate commit so it can be dropped if preferred).

The *driver versions needed to be updated as those versions don't have arch properties (they only have x86 or x86_64 binaries listed in the default repository file). Figured it was easiest to go for the first (latest?) listed versions of each.