### PR TITLE
Add name and url to project response

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/AjaxController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/AjaxController.groovy
@@ -717,6 +717,8 @@ class AjaxController {
             fieldNames.addAll(fieldList.name.unique().sort() as List<String>)
             result.data = exportService.exportJson(taskList, fieldList)
             result.projectId = project.id
+            result.name = project.name
+            result.url = grailsLinkGenerator.link(absolute: true, controller: 'project', action: 'index', id: project.id)
             result.institutionId = project.institution.id
 
             result.success = true


### PR DESCRIPTION
Intended to give human-readable context when capturing metadata about a project in CEMNT. It'll be used to build a link back to the project in DigiVol when displaying information about the project in CEMNT.