### PR TITLE
DG-138 Fixed issue in Template admin preventing page reload

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/TemplateFieldController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TemplateFieldController.groovy
@@ -67,7 +67,7 @@ class TemplateFieldController {
             bindData(templateField, params)
             if (!templateField.hasErrors() && templateField.save(flush: true)) {
                 flash.message = message(code: 'default.updated.message',
-                         args: [message(code: 'templateField.label', default: 'TemplateField'), templateField.id]) as String
+                         args: [message(code: 'templateField.label', default: 'TemplateField'), templateField.fieldType.label ]) as String
                 redirect(controller: 'template', action: "manageFields", id: templateField.template.id)
             } else {
                 render(view: "edit", model: [templateFieldInstance: templateField])
@@ -86,14 +86,15 @@ class TemplateFieldController {
         }
         def templateField = TemplateField.get(params.long('id'))
         if (templateField) {
+            def fieldLabel = templateField.fieldType.label
             try {
                 templateField.delete(flush: true)
                 flash.message = message(code: 'default.deleted.message',
-                         args: [message(code: 'templateField.label', default: 'TemplateField'), params.id]) as String
+                         args: [message(code: 'templateField.label', default: 'TemplateField'), fieldLabel]) as String
                 redirect(controller: 'template', action: "manageFields", id: templateField.template.id)
             } catch (DataIntegrityViolationException e) {
                 String message = message(code: 'default.not.deleted.message',
-                          args: [message(code: 'templateField.label', default: 'TemplateField'), params.id])
+                          args: [message(code: 'templateField.label', default: 'TemplateField'), fieldLabel])
                 flash.message = message
                 log.error(message, e)
                 redirect(action: "show", id: params.id)

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -226,6 +226,8 @@ templateField.label=TemplateField
 templateField.movedown.max=Field "{0}" ({1}) is already at the lowest position.
 templateField.moveup.max=Field "{0}" ({1}) is already at the highest position.
 templateField.add.order=Field "{0}" ({1}) has no display order. The field has been added to the end of the list.
+templateField.field.added=Template Field {0} successfully added.
+templateField.field.removed=Template Field {0} successfully removed.
 
 harvest.citation={0} digitised at {1} ({2})
 harvest.license.type=Creative Commons Attribution Australia

--- a/grails-app/views/template/addTemplateFieldFragment.gsp
+++ b/grails-app/views/template/addTemplateFieldFragment.gsp
@@ -35,32 +35,58 @@
 </form>
 
 <script>
+
     $('#btnSaveField').click(function (e) {
         e.preventDefault();
-        var fieldType = encodeURIComponent($("#fieldName").val());
+
+        const fieldType = encodeURIComponent($("#fieldName").val());
         if (fieldType) {
-            var url = "${createLink(controller:'template', action:'addField', id:templateInstance.id)}?fieldType=" + fieldType;
+            $('#btnCancelAddField').prop('disabled', 'disabled');
+            $('#btnSaveField').prop('disabled', 'disabled');
 
-            var classifier = $('#fieldTypeClassifier').val();
-            if (classifier) {
-                url += "&fieldTypeClassifier=" + encodeURIComponent(classifier);
+            const url = "${createLink(controller: 'template', action: 'addField')}";
+            let data = {
+                id: ${templateInstance.id},
+                fieldType: fieldType
             }
 
-            var label = $("#label").val();
-            if (label) {
-                url += "&label=" + encodeURIComponent(label);
-            }
-            var category = $("#category").val();
-            if (category) {
-                url += "&category=" + encodeURIComponent(category);
-            }
-            var type = $("#type").val();
-            if (type) {
-                url += "&type=" + encodeURIComponent(type);
-            }
-            window.location = url;
+            let classifier = $('#fieldTypeClassifier').val();
+            if (classifier) data.fieldTypeClassifier = encodeURIComponent(classifier);
+
+            let label = $("#label").val();
+            if (label) data.label = encodeURIComponent(label);
+
+            let category = $("#category").val();
+            if (category) data.category = encodeURIComponent(category);
+
+            let type = $("#type").val();
+            if (type) data.type = encodeURIComponent(type);
+
+            $.ajax({
+                type: "POST",
+                url: url,
+                data: data,
+                dataType: "json"
+            }).done(function(data, textStatus, jqXHR) {
+                if (data['result'] === true) {
+                    window.location.reload();
+                    return false;
+                } else {
+                    if (data.message) {
+                        alert(data.message);
+                    }
+                    $('#btnCancelAddField').prop('disabled', '');
+                    $('#btnSaveField').prop('disabled', '');
+                }
+            }).fail(function(jqXHR, textStatus, errorThrown) {
+                console.log("Error textStatus: " + textStatus);
+                console.log("errorThrown: " + errorThrown);
+                $('#btnCancelAddField').prop('disabled', '');
+                $('#btnSaveField').prop('disabled', '');
+
+                alert('There was an error adding the field: ' + errorThrown);
+            });
         }
-
     });
 
     $("#btnCancelAddField").click(function (e) {

--- a/grails-app/views/template/manageFields.gsp
+++ b/grails-app/views/template/manageFields.gsp
@@ -237,7 +237,6 @@
 
         $('#btnSaveField').click(function (e) {
             e.preventDefault();
-            console.log('test');
         });
 
     });

--- a/grails-app/views/template/manageFields.gsp
+++ b/grails-app/views/template/manageFields.gsp
@@ -126,116 +126,121 @@
             var fieldId = $(this).parents("[fieldId]").attr('fieldId');
             if (fieldId) {
                 window.location.href = "${createLink(controller: 'template', action: 'moveFieldUp')}?fieldId=" + fieldId;
-                    }
-                });
+            }
+        });
 
-                $(".btnMoveFieldDown").click(function(e) {
-                    e.preventDefault();
-                    var fieldId = $(this).parents("[fieldId]").attr('fieldId');
-                    if (fieldId) {
-                        window.location.href = "${createLink(controller: 'template', action: 'moveFieldDown')}?fieldId=" + fieldId;
-                    }
-                });
+        $(".btnMoveFieldDown").click(function(e) {
+            e.preventDefault();
+            var fieldId = $(this).parents("[fieldId]").attr('fieldId');
+            if (fieldId) {
+                window.location.href = "${createLink(controller: 'template', action: 'moveFieldDown')}?fieldId=" + fieldId;
+            }
+        });
 
-                $(".btnMoveFieldAnywhere").click(function(e) {
-                    e.preventDefault();
-                    var fieldId = $(this).parents("[fieldId]").attr('fieldId');
-                    if (fieldId) {
-                        $("#oldPosition").val($(this).parents("[fieldOrder]").attr("fieldOrder"));
-                        $("#dialogFieldId").val(fieldId);
-                        $("#dialog").dialog( "open" );
-                    }
-                });
+        $(".btnMoveFieldAnywhere").click(function(e) {
+            e.preventDefault();
+            var fieldId = $(this).parents("[fieldId]").attr('fieldId');
+            if (fieldId) {
+                $("#oldPosition").val($(this).parents("[fieldOrder]").attr("fieldOrder"));
+                $("#dialogFieldId").val(fieldId);
+                $("#dialog").dialog( "open" );
+            }
+        });
 
-                $("#btnCancelMove").click(function(e) {
-                    e.preventDefault();
-                    $("#dialog").dialog( "close" );
-                });
+        $("#btnCancelMove").click(function(e) {
+            e.preventDefault();
+            $("#dialog").dialog( "close" );
+        });
 
-                $("#btnApplyMove").click(function(e) {
-                    e.preventDefault();
-                    var fieldId = $("#dialogFieldId").val();
-                    var newPosition = $("#newPosition").val();
-                    window.location.href = "${createLink(controller: 'template', action: 'moveFieldToPosition', id: templateInstance.id)}?fieldId=" + fieldId + "&newOrder=" + newPosition
-                });
+        $("#btnApplyMove").click(function(e) {
+            e.preventDefault();
+            var fieldId = $("#dialogFieldId").val();
+            var newPosition = $("#newPosition").val();
+            window.location.href = "${createLink(controller: 'template', action: 'moveFieldToPosition', id: templateInstance.id)}?fieldId=" + fieldId + "&newOrder=" + newPosition
+        });
 
-                $( "#dialog" ).dialog({
-                    minHeight: 200,
-                    minWidth: 400,
-                    resizable: false,
-                    autoOpen: false
-                });
+        $( "#dialog" ).dialog({
+            minHeight: 200,
+            minWidth: 400,
+            resizable: false,
+            autoOpen: false
+        });
 
-                $("#btnCleanUpOrdering").click(function(e) {
-                    e.preventDefault();
-                    window.location.href = "${createLink(controller: 'template', action: 'cleanUpOrdering', id: templateInstance.id)}";
-                });
+        $("#btnCleanUpOrdering").click(function(e) {
+            e.preventDefault();
+            window.location.href = "${createLink(controller: 'template', action: 'cleanUpOrdering', id: templateInstance.id)}";
+        });
 
-                $("#btnAddField").click(function(e) {
-                    e.preventDefault();
-                    var options = {
-                        title:"Add field to template",
-                        url:"${createLink(action: 'addTemplateFieldFragment', id: templateInstance.id)}",
-                        onClose : function() { }
-                    };
+        $("#btnAddField").click(function(e) {
+            e.preventDefault();
+            var options = {
+                title:"Add field to template",
+                url:"${createLink(action: 'addTemplateFieldFragment', id: templateInstance.id)}",
+                onClose : function() { }
+            };
 
-                    bvp.showModal(options);
-                });
+            bvp.showModal(options);
+        });
 
-                $(".btnDeleteField").click(function(e) {
-                    e.preventDefault();
-                    var fieldId = $(this).parents("[fieldId]").attr("fieldId");
-                    if (fieldId) {
-                        if (confirm("Are you sure you wish to delete this field from the template?")) {
-                            window.location.href = "${createLink(controller: 'template', action: 'deleteField', id: templateInstance.id)}?fieldId=" + fieldId;
-                        }
-                    }
-                });
+        $(".btnDeleteField").click(function(e) {
+            e.preventDefault();
+            var fieldId = $(this).parents("[fieldId]").attr("fieldId");
+            if (fieldId) {
+                if (confirm("Are you sure you wish to delete this field from the template?")) {
+                    window.location.href = "${createLink(controller: 'template', action: 'deleteField', id: templateInstance.id)}?fieldId=" + fieldId;
+                }
+            }
+        });
 
-                $(".btnEditField").click(function(e) {
-                    e.preventDefault();
-                    var fieldId = $(this).parents("[fieldId]").attr("fieldId");
-                    if (fieldId) {
-                        window.location.href = "${createLink(controller: 'templateField', action: 'edit')}/" + fieldId;
-                    }
-                });
+        $(".btnEditField").click(function(e) {
+            e.preventDefault();
+            var fieldId = $(this).parents("[fieldId]").attr("fieldId");
+            if (fieldId) {
+                window.location.href = "${createLink(controller: 'templateField', action: 'edit')}/" + fieldId;
+            }
+        });
 
-                $("#btnPreviewTemplate").click(function(e) {
-                    e.preventDefault();
-                    window.open("${createLink(controller: 'template', action: 'preview', id: templateInstance.id)}", "TemplatePreview");
-                });
+        $("#btnPreviewTemplate").click(function(e) {
+            e.preventDefault();
+            window.open("${createLink(controller: 'template', action: 'preview', id: templateInstance.id)}", "TemplatePreview");
+        });
 
-                $("#btnExportAsCSV").click(function(e) {
-                    e.preventDefault();
-                    window.open("${createLink(controller: 'template', action: 'exportFieldsAsCSV', id: templateInstance.id)}", "CSVExport");
-                });
+        $("#btnExportAsCSV").click(function(e) {
+            e.preventDefault();
+            window.open("${createLink(controller: 'template', action: 'exportFieldsAsCSV', id: templateInstance.id)}", "CSVExport");
+        });
 
-                $("#btnImportFromCSV").click(function(e) {
-                    e.preventDefault();
-                    if (confirm("This will remove all existing fields, and replace them with the contents of the selected file. Are you sure?")) {
-                        $("form").submit();
-                    }
-                });
+        $("#btnImportFromCSV").click(function(e) {
+            e.preventDefault();
+            if (confirm("This will remove all existing fields, and replace them with the contents of the selected file. Are you sure?")) {
+                $("form").submit();
+            }
+        });
 
-                // Context sensitive help popups
-                $("a.fieldHelp").each(function() {
-                var self = this;
-                    $(self).qtip({
-                        content: $(self).attr('title'),
-                        position: {
-                            at: "top left",
-                            my: "bottom right"
-                        },
-                        style: {
-                            classes: 'qtip-bootstrap'
-                        }
-                    }).bind('click', function(e) { e.preventDefault(); return false; });
-                });
+        // Context sensitive help popups
+        $("a.fieldHelp").each(function() {
+            var self = this;
+            $(self).qtip({
+                content: $(self).attr('title'),
+                position: {
+                    at: "top left",
+                    my: "bottom right"
+                },
+                style: {
+                    classes: 'qtip-bootstrap'
+                }
+            }).bind('click', function(e) { e.preventDefault(); return false; });
+        });
 
-                // Initialize input type file
-                $('input[type=file]').bootstrapFileInput();
+        // Initialize input type file
+        $('input[type=file]').bootstrapFileInput();
 
-            });
+        $('#btnSaveField').click(function (e) {
+            e.preventDefault();
+            console.log('test');
+        });
+
+    });
 
 </asset:script>
 </body>


### PR DESCRIPTION
Fixed issue where manageFields page was not redirecting back to itself after adding a new field to the template (Chrome was cancelling the redirect for some reason).
Page now submits new field via xhr, waits for successful response and then reloads the page. Added better error handling as well.
manageFields.gsp - tab re-alignment