### PR TITLE
DG-72 Fixed issue where background and banner images were being cached when updated

### DIFF
--- a/grails-app/services/au/org/ala/volunteer/ProjectService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ProjectService.groovy
@@ -1187,6 +1187,16 @@ class ProjectService implements EventPublisher {
     }
 
     /**
+     * Returns a queryString parameter to assist with cache-busting images.
+     * @param project the project being used.
+     * @return the querystring parameter consisting of the datetime the project was last updated.
+     */
+    String cacheBust(Project project) {
+        if (!project) return ""
+        return "v=${project.lastUpdated.format(DateConstants.DATE_FORMAT_QS)}"
+    }
+
+    /**
      * Checks if the provided Project has enabled support for multiple transcriptions. Also checks if project is of a
      * supported type (cameratrap/audio).
      * @param project the project to check

--- a/grails-app/services/au/org/ala/volunteer/ProjectService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ProjectService.groovy
@@ -741,6 +741,10 @@ class ProjectService implements EventPublisher {
             } else {
                 log.info "Image Ok. No scaling required."
             }
+
+            // Update project lastUpdated
+            tagProjectLastUpdated(projectInstance)
+
             return true
         } catch (Exception ex) {
             log.error("Could not check and resize expedition image for $projectInstance", ex)
@@ -1192,6 +1196,17 @@ class ProjectService implements EventPublisher {
                 filePng.delete()
             }
         }
+
+        tagProjectLastUpdated(project)
+    }
+
+    /**
+     * Force an update of the project.lastUpdated value as this is used for the cache busting query string parameter.
+     *
+     */
+    private def tagProjectLastUpdated(Project project) {
+        project.lastUpdated = new Date()
+        project.save(flush: true)
     }
 
     /**

--- a/grails-app/services/au/org/ala/volunteer/VolunteerStatsService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/VolunteerStatsService.groovy
@@ -177,7 +177,7 @@ class VolunteerStatsService {
             if (topic instanceof ProjectForumTopic) {
                 def forumProject = ((ProjectForumTopic) topic).project
                 forumName = forumProject.name
-                thumbnail = projectService.getFeaturedImage(forumProject)
+                thumbnail = projectService.getFeaturedImage(forumProject) + "?" + projectService.cacheBust(forumProject)
                 forumUrl = grailsLinkGenerator.link(controller: 'forum', action: 'projectForum', params: [projectId: forumProject.id])
             } else if (topic instanceof TaskForumTopic) {
                 def task = ((TaskForumTopic) topic).task

--- a/grails-app/taglib/au/org/ala/volunteer/ForumTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/ForumTagLib.groovy
@@ -225,8 +225,9 @@ class ForumTagLib {
                                     }
                                     if (topic instanceof ProjectForumTopic) {
                                         def projectFeaturedImage = projectService.getFeaturedImage((topic as ProjectForumTopic).project)
+                                        def imageUrl = projectFeaturedImage + "?" + projectService.cacheBust((topic as ProjectForumTopic).project)
                                         //delegate.img(src: (topic as ProjectForumTopic).project.featuredImage, width: '40')
-                                        delegate.img(src: projectFeaturedImage, width: '40')
+                                        delegate.img(src: imageUrl, width: '40')
                                     } else if (topic instanceof TaskForumTopic) {
                                         def mm = (topic as TaskForumTopic).task.multimedia?.first()
                                         if (mm) {

--- a/grails-app/taglib/au/org/ala/volunteer/TranscribeTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/TranscribeTagLib.groovy
@@ -873,7 +873,7 @@ class TranscribeTagLib {
         if (task?.project?.institution) {
             out << institutionService.getLogoImageUrl(task.project.institution)
         } else if (task?.project) {
-            out << projectService.getFeaturedImage(task.project)
+            out << projectService.getFeaturedImage(task.project) + "?" + projectService.cacheBust(task.project)
         } else {
             out << grailsLinkGenerator.resource( file: '/logoDigivolGrey.png' )
         }

--- a/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
@@ -243,7 +243,8 @@ class VolunteerTagLib {
      * @attr preLoad if true, allows for pre-load and resizing (jquery plugin)
      */
     def featuredImage = { attrs, body ->
-        def featuredImageUrl = projectService.getFeaturedImage(attrs.project as Project)
+        def featuredImageUrl = projectService.getFeaturedImage(attrs.project as Project) + "?" +
+                projectService.cacheBust(attrs.project as Project)
         def cssClass = attrs.remove("class")
         def style = attrs.remove("style")
         def dataErrorUrl = attrs.remove("data-error-url")

--- a/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
@@ -209,7 +209,8 @@ class VolunteerTagLib {
     }
 
     def backgroundImageUrl = { attrs, body ->
-        out << projectService.getBackgroundImage(attrs.project as Project)
+        out << projectService.getBackgroundImage(attrs.project as Project) + "?" +
+                projectService.cacheBust(attrs.project as Project)
     }
 
     /**
@@ -219,7 +220,8 @@ class VolunteerTagLib {
      * @attr style Any custom CSS style to add to the element
      */
     def backgroundImage = { attrs, body ->
-        def backgroundImageUrl = projectService.getBackgroundImage(attrs.project as Project)
+        def backgroundImageUrl = projectService.getBackgroundImage(attrs.project as Project) + "?" +
+                projectService.cacheBust(attrs.project as Project)
         def cssClass = attrs.remove("class")
         def style = attrs.remove("style")
 

--- a/src/main/groovy/au/org/ala/volunteer/DateConstants.groovy
+++ b/src/main/groovy/au/org/ala/volunteer/DateConstants.groovy
@@ -4,5 +4,6 @@ class DateConstants {
 
     public static String DATE_TIME_FORMAT = "dd MMM yyyy HH:mm:ss"
     public static String DATE_FORMAT_SHORT = "dd/MM/yyyy"
+    public static String DATE_FORMAT_QS = "yyyyMMddHHmmsssss"
 
 }


### PR DESCRIPTION
Added cache-busting query string parameter. Also added a tagging method to update the project lastUpdated column to ensure it was always being updated when updating the images (doesn't otherwise have a db update).