### PR TITLE
DG-70 Updated project summary to display short description

### DIFF
--- a/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/volunteer/VolunteerTagLib.groovy
@@ -1059,17 +1059,17 @@ class VolunteerTagLib {
     def truncate = { attrs, body ->
         final ELLIPSIS = attrs.ellipse ?: '…'
         def maxLength = attrs.maxlength
-        final bodyText = body().replaceAll("<[^>]*>", '') // strip out html tags
+        final bodyText = body().replaceAll("<[^>]*>", '').trim() // strip out html tags and white space
 
         if (maxLength == null || !maxLength.isInteger() || maxLength.toInteger() <= 0) {
-            throw new Exception("The attribute 'maxlength' must an integer greater than 3. Provided value: $maxLength")
+            throw new Exception("The attribute 'maxlength' must be an integer greater than 3. Provided value: $maxLength")
         } else {
             maxLength = maxLength.toInteger()
         }
         if (maxLength <= ELLIPSIS.size()) {
             throw new Exception("The attribute 'maxlength' must be greater than 3. Provided value: $maxLength")
         }
-        if (bodyText.length() > maxLength) {
+        if ((bodyText.length() + (ELLIPSIS.size() + 1)) > maxLength) {
             out << bodyText[0..maxLength - (ELLIPSIS.size() + 1)] + ELLIPSIS
         } else {
             out << bodyText

--- a/grails-app/views/project/_ProjectListDetailsView.gsp
+++ b/grails-app/views/project/_ProjectListDetailsView.gsp
@@ -28,7 +28,7 @@
                                 </div>
                             </div>
                             <div class="col-xs-9 ${projectSummary.project?.inactive ? 'expedition-inactive' : ''}">
-                                <g:render template="/project/projectSummary" model="[projectSummary: projectSummary, includeDescription: true]" />
+                                <g:render template="/project/projectSummary" model="[projectSummary: projectSummary, includeDescription: true, maxDescriptionLen: 250]" />
                             </div>
                         </div>
                     </div>

--- a/grails-app/views/project/_projectSummary.gsp
+++ b/grails-app/views/project/_projectSummary.gsp
@@ -19,7 +19,16 @@
     </div>
 
     <g:if test="${includeDescription}">
-        <g:set var="descrptionSnippet"><cl:truncate maxlength="${params.mode == 'list' ? '150' : '85'}">${raw(projectSummary.project?.description)}</cl:truncate></g:set>
+        <g:set var="descrptionSnippet">
+            <cl:truncate maxlength="${Integer.toString(maxDescriptionLen) ?: '200'}">
+                <g:if test="${projectSummary.project?.shortDescription}">
+                    ${raw(projectSummary.project?.shortDescription)}
+                </g:if>
+                <g:else>
+                    ${raw(projectSummary.project?.description)}
+                </g:else>
+            </cl:truncate>
+        </g:set>
         <p class="projectDescription">${raw(descrptionSnippet)}</p>
     </g:if>
 


### PR DESCRIPTION
Updated project summary display to display the short description instead of long description (if exists) and moved max length to the template definition call (instead of defined by `params.mode`).
Truncate method was updated to include elipsis in text length before deciding whether to truncate or not. This fixed issues where text of exactly max length still had elipsis added. Trimming whitespace was also required due to the template gsp definition.