### PR TITLE
DG-65 Fixed CSV wrong content type

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/AdminController.groovy
@@ -12,6 +12,8 @@ import org.jooq.Transaction
 import org.springframework.web.multipart.MultipartHttpServletRequest
 import org.springframework.web.multipart.MultipartFile
 
+import javax.servlet.ServletOutputStream
+import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -657,7 +659,7 @@ class AdminController {
         }
 
         response.setHeader("Content-Disposition", "attachment;filename=expedition-summary.csv")
-        response.addHeader("Content-type", "text/plain")
+        response.setContentType('text/csv;charset=utf-8')
         def sdf = new SimpleDateFormat("yyyy-MM-dd")
 
         def dateStr = { Date d ->
@@ -674,7 +676,8 @@ class AdminController {
             return ""
         }
 
-        def writer = new CSVWriter((Writer) response.writer,  {
+        def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)ß
+        def writer = new CSVWriter(osw,  {
             'Expedition Id' { it.project.id }
             'Expedtion Name' { it.project.featuredLabel }
             'Institution' { it.project.institution ? it.project.institution.name : it.project.featuredOwner }
@@ -700,7 +703,9 @@ class AdminController {
         for (def row : data) {
             writer << row
         }
-        response.flushBuffer()
+        //response.flushBuffer()
+        osw.flush()
+        osw.close()
     }
 
     def reindexAllTasks() {

--- a/grails-app/controllers/au/org/ala/volunteer/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/AdminController.groovy
@@ -676,7 +676,7 @@ class AdminController {
             return ""
         }
 
-        def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)ß
+        def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)
         def writer = new CSVWriter(osw,  {
             'Expedition Id' { it.project.id }
             'Expedtion Name' { it.project.featuredLabel }

--- a/grails-app/controllers/au/org/ala/volunteer/AjaxController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/AjaxController.groovy
@@ -14,6 +14,8 @@ import groovy.util.logging.Slf4j
 import org.apache.commons.lang.StringUtils
 import org.springframework.web.multipart.MultipartHttpServletRequest
 
+import javax.servlet.ServletOutputStream
+import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import groovy.sql.Sql
@@ -114,12 +116,14 @@ class AjaxController {
 
         // Pre-create the writer and write the headings straight away to prevent a read timeout.
         def writer
+        def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)
+
         if (params.wt && params.wt == 'csv') {
             def nodata = params.nodata ?: 'nodata'
 
-            response.addHeader("Content-type", "text/plain")
+            response.setContentType('text/csv;charset=utf-8')
 
-            writer = new CSVHeadingsWriter((Writer) response.writer, {
+            writer = new CSVHeadingsWriter(osw, {
                 'user_id' { it[0] }
                 'email' { it[1] }
                 'display_name' { it[2] }
@@ -137,7 +141,7 @@ class AjaxController {
                 'is_forum_mod' { it[14] }
             })
             writer.writeHeadings()
-            response.flushBuffer()
+            osw.flush()
         }
 
         def asyncCounts = Task.async.withStatelessSession {
@@ -258,7 +262,9 @@ class AjaxController {
             for (def row : report) {
                 writer << row
             }
-            response.flushBuffer()
+            //response.flushBuffer()
+            osw.flush()
+            osw.close()
         } else {
             respond report
         }
@@ -305,10 +311,11 @@ class AjaxController {
 
     def expeditionBiocacheData() {
         setNoCache()
-        response.addHeader("Content-type", "text/plain")
+        response.setContentType('text/csv;charset=utf-8')
 
         if (params.id) {
-            def projectInstance = Project.get(params.id)
+            log.debug("Generating expedition biocache data for project id ${params.id}")
+            def projectInstance = Project.get(params.long('id'))
             if (projectInstance) {
 
                 def findValue = { List<Field> fieldValues, String name ->
@@ -329,14 +336,17 @@ class AjaxController {
                 }
 
                 def fieldNames = new CSVWriterColumnsBuilder(columns).columns.collect { it.key }
-                def writer = new CSVWriter(response.writer, columns)
+                def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)
+                def writer = new CSVWriter(osw, columns)
                 def fields = Field.findAll("from Field as f where f.task in (from Task as task where task.project = :project) and f.transcription is null and f.superceded = false and f.name in (:fields)",[project: projectInstance, fields: fieldNames]).groupBy { it.task }
+                log.debug("Expedition biocache data found ${fields.size()} tasks with fields for project ${projectInstance.name}")
 
                 for (Task t : fields.keySet()) {
                     writer << [task: t, fieldValues: fields[t]]
                 }
 
-                response.writer.flush()
+                osw.flush()
+                osw.close()
             }
         } else {
             render([success: false, message:"Unable to retrieve project with id '${params.id}'"] as JSON)

--- a/grails-app/controllers/au/org/ala/volunteer/PicklistController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/PicklistController.groovy
@@ -7,6 +7,8 @@ import groovy.json.JsonOutput
 import org.apache.commons.lang3.StringEscapeUtils
 import org.springframework.dao.DataIntegrityViolationException
 
+import java.nio.charset.StandardCharsets
+
 class PicklistController {
 
     static allowedMethods = [upload: "POST", save: "POST", update: "POST", delete: "POST"]
@@ -227,8 +229,8 @@ class PicklistController {
         def picklist = Picklist.get(params.long('picklistId'))
         if (picklist) {
             response.setHeader("Content-disposition", "attachment;filename=" + picklist.name + ".csv")
-            response.contentType = "text/csv"
-            OutputStreamWriter writer = new OutputStreamWriter(response.outputStream)
+            response.setContentType('text/csv;charset=utf-8')
+            OutputStreamWriter writer = new OutputStreamWriter(response.outputStream, StandardCharsets.UTF_8)
             writeItemsCsv(writer, picklist, params.institutionCode as String)
             writer.flush()
             writer.close()

--- a/grails-app/controllers/au/org/ala/volunteer/TaskController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TaskController.groovy
@@ -9,7 +9,9 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.multipart.MultipartHttpServletRequest
 
 import javax.imageio.ImageIO
+import javax.servlet.ServletOutputStream
 import java.awt.image.BufferedImage
+import java.nio.charset.StandardCharsets
 
 class TaskController {
 
@@ -807,8 +809,9 @@ class TaskController {
         if (project) {
             def profile = ProjectStagingProfile.findByProject(project)
 
-            response.addHeader("Content-type", "text/plain")
-            def writer = new BVPCSVWriter( (Writer) response.writer,  {
+            response.setContentType('text/csv;charset=utf-8')
+            def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)
+            def writer = new BVPCSVWriter(osw,  {
                 'imageName' { it.name }
                 'url' { it.url }
             })
@@ -827,7 +830,8 @@ class TaskController {
                 writer << it
             }
 
-            response.writer.flush()
+            osw.flush()
+            osw.close()
         }
     }
 

--- a/grails-app/services/au/org/ala/volunteer/ExportService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ExportService.groovy
@@ -8,6 +8,7 @@ import org.apache.commons.lang.SerializationUtils
 import org.jooq.tools.StringUtils
 
 import javax.servlet.http.HttpServletResponse
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import java.util.zip.ZipOutputStream
@@ -189,13 +190,13 @@ class ExportService {
 
         def filename = "Project-" + (cleanFilename(project.featuredLabel) ?: project.id) + "-DwC"
 
-        response.setHeader("Content-Disposition", "attachment;filename=" + filename +".csv");
-        response.setContentType("text/plain");
-        OutputStream fout = response.getOutputStream();
-        OutputStream bos = new BufferedOutputStream(fout);
-        OutputStreamWriter outputwriter = new OutputStreamWriter(bos);
+        response.setHeader("Content-Disposition", "attachment;filename=" + filename +".csv")
+        response.setContentType('text/csv;charset=utf-8')
+        OutputStream fout = response.getOutputStream()
+        OutputStream bos = new BufferedOutputStream(fout)
+        OutputStreamWriter outputwriter = new OutputStreamWriter(bos, StandardCharsets.UTF_8)
 
-        CSVWriter writer = new CSVWriter(outputwriter);
+        CSVWriter writer = new CSVWriter(outputwriter)
         // write header line (field names)
         writer.writeNext(columnNames as String[])
         log.debug("Wrote column names in {}ms", sw.elapsed(MILLISECONDS))
@@ -385,7 +386,7 @@ class ExportService {
      */
     def cleanFilename(String filename) {
         if (StringUtils.isEmpty(filename)) return
-        String cleanFilename = filename.replaceAll(Pattern.compile("[ \\\\/:*?\"\'<>|\\]\\[.;\${}&%#@!]"), "")
+        String cleanFilename = filename.replaceAll(Pattern.compile("[ \\\\/:*?\"\'<>|\\]\\[.;,\${}&%#@!]"), "")
         return cleanFilename
     }
 

--- a/grails-app/services/au/org/ala/volunteer/TemplateFieldService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/TemplateFieldService.groovy
@@ -3,8 +3,13 @@ package au.org.ala.volunteer
 import grails.gorm.transactions.Transactional
 import org.springframework.web.multipart.MultipartFile
 
+import javax.servlet.ServletOutputStream
+import java.nio.charset.StandardCharsets
+
 @Transactional(readOnly = true)
 class TemplateFieldService {
+
+    def exportService
 
     @Transactional
     def importFieldsFromCSV(Template template, MultipartFile file) {
@@ -42,15 +47,16 @@ class TemplateFieldService {
     }
 
     def exportFieldToCSV(Template templateInstance, response) {
-
         if (!templateInstance) {
             return
         }
+        def fileName = exportService.cleanFilename("${templateInstance.name}_fields")
+        if (!fileName) fileName = "digivol_template_fields.csv"
+        response.setHeader("Content-Disposition", "attachment;filename=${fileName}.csv")
+        response.setContentType('text/csv;charset=utf-8')
 
-        response.setHeader("Content-Disposition", "attachment;filename=fields.txt");
-        response.addHeader("Content-type", "text/plain")
-
-        def writer = new BVPCSVWriter( (Writer) response.writer,  {
+        def osw = new OutputStreamWriter(response.outputStream as ServletOutputStream, StandardCharsets.UTF_8)
+        def writer = new BVPCSVWriter(osw,{
             'fieldType' { it.fieldType?.toString() }
             'label' { it.label ?: '' }
             'defaultValue' { it.defaultValue ?: '' }
@@ -70,6 +76,7 @@ class TemplateFieldService {
         for (def field : fields) {
             writer << field
         }
-        response.writer.flush()
+        osw.flush()
+        osw.close()
     }
 }


### PR DESCRIPTION
 - Corrected CSV export content types from text/plain to text/csv and utilising UTF-8 for special characters in datasets (#528).
 - Also corrected a bug where a comma in an expedition name fouled the csv filename generation.

Testing
 - 
**Template Field export**
 - Navigate to edit template fields: [Template Field export](https://digivol-test.ala.org.au/template/manageFields/791101)
 - Click "Export as CSV"
 - Save file and check CSV

**Admin project summary report**
 - Navigate to [Admin/Project Summary Report](https://digivol-test.ala.org.au/report/projectSummary)
 - Click on "Project Summary Report"
 - Click on "Generate Report"
 - When report generated (Pending changes to Download), save file and check CSV

**Ajax user report**
 - Navigate to [Admin/User Reporting](https://digivol-test.ala.org.au/report/userReport)
 - Select a short timespan (e.g. 1 week in September 2025) and click Generate Report
 - When report generated (Pending changes to Download), save file and check CSV

**Ajax expeditionBiocacheData** 
 - Navigate to this [WS URL](https://devt.ala.org.au/digivol/ws/expeditionBiocacheData/456540210).
 - Save and check CSV

**Picklist download**
 - Navigate to [Admin/Manage Picklists](https://digivol-test.ala.org.au/picklist/index)
 - In Picklist, select "country"
 - In Collection Code, select "Australian National Herbarium (Orchidaceae)" and click "Load items into text area"
 - Click "Download items as CSV"
 - Save and check CSV

**Stats institution stats download**
 - Navigate to [Admin/Stats downloads tab](https://digivol-test.ala.org.au/stats/index)
 - Select an instituion and click the link (Australian Museum Entomology will have records)
 - Save and check CSV

**Stats export csv report**
 - Navigate to [Admin/Stats Reports by Date tab](https://digivol-test.ala.org.au/stats/index)
 - Select 1 Jan 2025 in the "From" field
 - Click the "Search" button.
 - Under the 'Active Transcribers' table, click the "Download" button.
 - Save and check CSV

**Task export staged tasks**
 - Navigate to this [expedition staging](https://digivol-test.ala.org.au/task/staging?projectId=3016873)
 - Click the "Actions" button and select "Export staged tasks as CSV"
 - Save and check CSV

**Export Expedition Data**
 - Navigate to [Admin/Manage Expeditions](https://digivol-test.ala.org.au/project/manage)
 - Identify an expedition and click the "Export Expedition (all tasks) icon.
 - On the Export dialog, make sure 'Single de-normalised CSV file' is selected and click "Export"
 - Save and check CSV
 - Navigate to this [expedtion](https://digivol-test.ala.org.au/task/projectAdmin/3050453)
 - Click the "Tools" button and select "Export all tasks"
 - Save and check CSV - filename should be complete, with file extension.

