### PR TITLE
DG-198 Fixed issue with task view tutorial button

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
@@ -48,7 +48,7 @@ class ProjectController {
         def showTutorial = (params.showTutorial == "true")
 
         // If the tutorial has been requested but the field is empty, redirect to tutorial index.
-        if (showTutorial && projectInstance.tutorials.size() == 0) {
+        if (showTutorial && (!projectInstance.tutorialLinks && projectInstance.tutorials.size() == 0)) {
             redirect(controller: "tutorials", action: "index")
             return
         }

--- a/grails-app/views/layouts/digivol-task.gsp
+++ b/grails-app/views/layouts/digivol-task.gsp
@@ -110,12 +110,12 @@
                 <button type="button" class="btn btn-default" id="showNextFromProject" data-skip="true" data-container="body"
                         title="Skip to the next image">Skip</button>
                 <vpf:taskTopicButton task="${taskInstance}" class="btn btn-default"/>
-                <g:if test="${taskInstance?.project?.tutorialLinks}">
+                <g:if test="${taskInstance?.project?.tutorialLinks || taskInstance?.project?.tutorials?.size() > 0}">
                     <g:link class="btn btn-default" controller="project" action="index" id="${taskInstance?.project?.id}"
-                            target="_blank" params="${[showTutorial: true]}">View Tutorial</g:link>
+                            target="_blank" params="${[showTutorial: true]}">View Tutorials</g:link>
                 </g:if>
                 <g:else>
-                    <g:link class="btn btn-default" controller="tutorials" action="index" target="_blank">View Tutorial</g:link>
+                    <g:link class="btn btn-default" controller="tutorials" action="groupList" params="${[institution: taskInstance?.project?.institution?.id]}" target="_blank">View Tutorials</g:link>
                 </g:else>
             </div>
 

--- a/grails-app/views/project/index.gsp
+++ b/grails-app/views/project/index.gsp
@@ -92,7 +92,9 @@
                                 <g:else>
                                     <h4>Expedition Tutorial List</h4>
                                     <div id="tutorial-intro">
-                                        <p>No tutorial information available</p>
+                                        <p>No tutorial information available.</p>
+                                        <p>You can find other tutorials for ${projectInstance.institution.name}
+                                        <g:link controller="tutorials" action="groupList" params="${[institution: projectInstance.institution.id]}" target="_blank">here</g:link>.</p>
                                     </div>
                                 </g:else>
                             </div>


### PR DESCRIPTION
 - Corrected logic checking for tutorials when initialising button link
 - Corrected logic when displaying tutorial info coming from task (when no info set)
 - Updated tutorial info display, providing link to institution tutorial list

### Testing

1. Navigate to [Admin/Manage Expeditions](https://digivol-test.ala.org.au/project/manage).
2. Select an expedition to edit settings.
3. Select Tutorial Info.
4. Expedition should have at least one tutorial and at least one task.

Test the following: 
- A) Null Tutorial Info/No tutorial selected
- B) Not null Tutorial Info/No tutorial selected
- C) Null Tutorial/At least one tutorial selected
- D) Not null Tutorial/At least one tutorial selected

Expected Results:
 - Check expedition home page.
 A) No Tutorial Information button
 B) Tutorial Information button available, clicking should display Tutorial info
 C) Tutorial Information button available, clicking should display Tutorial info
 D) Tutorial Information button available, clicking should display Tutorial info
 - Check Task transcription page
 A) View Tutorials button should load Tutorials list for institution
 B) View Tutorials button should load Expedition home page and display Tutorial info
 C) View Tutorials button should load Expedition home page and display Tutorial info
 D) View Tutorials button should load Expedition home page and display Tutorial info