### PR TITLE
Deprecate/remove audio expeditions and templates

### DIFF
--- a/grails-app/controllers/au/org/ala/volunteer/LandingPageAdminController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/LandingPageAdminController.groovy
@@ -11,6 +11,7 @@ class LandingPageAdminController {
 
     def fileUploadService
     def settingsService
+    def projectTypeService
 
     def index(Integer max) {
         params.max = Math.min(max ?: 10, 100)
@@ -21,7 +22,7 @@ class LandingPageAdminController {
         def landingPageInstance = chainModel?.landingPage ?: new LandingPage()
         landingPageInstance.label = new HashSet<Label>()
         landingPageInstance.numberOfContributors = 10
-        ['landingPageInstance': landingPageInstance, projectTypes: ProjectType.listOrderByName()]
+        ['landingPageInstance': landingPageInstance, projectTypes: projectTypeService.getEnabledProjectTypes()]
     }
 
     def edit (LandingPage landingPageInstance) {
@@ -33,7 +34,7 @@ class LandingPageAdminController {
                 landingPageInstance = LandingPage.findById(landingPageId)
             }
         }
-        ['landingPageInstance': landingPageInstance, projectTypes: ProjectType.listOrderByName()]
+        ['landingPageInstance': landingPageInstance, projectTypes: projectTypeService.getEnabledProjectTypes()]
     }
 
     def editImage(LandingPage landingPageInstance) {

--- a/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
@@ -456,7 +456,7 @@ class ProjectController {
 
         if (project.errors.hasErrors()) {
             def institutionList = (userService.isSiteAdmin() ? Institution.listApproved([sort: 'name', order: 'asc']) : userService.getAdminInstitutionList())
-            def projectTypes = projectTypeService.getEnabledProjectTypes(project?.projectType)
+            def projectTypes = projectTypeService.getEnabledProjectTypes(project.projectType)
             render(view: 'create', model: [projectInstance: project, params: params, institutionList: institutionList, projectTypes: projectTypes])
             return
         } else {

--- a/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/ProjectController.groovy
@@ -38,6 +38,7 @@ class ProjectController {
     def groovyPageRenderer
     def templateService
     def settingsService
+    def projectTypeService
     Closure<DSLContext> jooqContext
 
     /**
@@ -421,7 +422,7 @@ class ProjectController {
         }
 
         def institutionList = (userService.isSiteAdmin() ? Institution.listApproved([sort: 'name', order: 'asc']) : userService.getAdminInstitutionList())
-        def projectTypes = ProjectType.listOrderByName()
+        def projectTypes = projectTypeService.getEnabledProjectTypes()
 
         [institutionList: institutionList, projectTypes: projectTypes]
     }
@@ -455,7 +456,7 @@ class ProjectController {
 
         if (project.errors.hasErrors()) {
             def institutionList = (userService.isSiteAdmin() ? Institution.listApproved([sort: 'name', order: 'asc']) : userService.getAdminInstitutionList())
-            def projectTypes = ProjectType.listOrderByName()
+            def projectTypes = projectTypeService.getEnabledProjectTypes(project?.projectType)
             render(view: 'create', model: [projectInstance: project, params: params, institutionList: institutionList, projectTypes: projectTypes])
             return
         } else {
@@ -463,7 +464,7 @@ class ProjectController {
                 log.error("Error creating project, reloading create page.")
                 flash.message = "An error occurred creating the Project."
                 def institutionList = (userService.isSiteAdmin() ? Institution.listApproved([sort: 'name', order: 'asc']) : userService.getAdminInstitutionList())
-                def projectTypes = ProjectType.listOrderByName()
+                def projectTypes = projectTypeService.getEnabledProjectTypes()
                 render(view: 'create', model: [params: params, institutionList: institutionList, projectTypes: projectTypes])
                 return
             }
@@ -534,7 +535,7 @@ class ProjectController {
 
             return [projectInstance: project,
                     templates      : editLists?.templates,
-                    projectTypes   : ProjectType.listOrderByName(),
+                    projectTypes   : projectTypeService.getEnabledProjectTypes(project.projectType),
                     institutionList: editLists?.insts,
                     labelColourMap : editLists?.catColourMap,
                     sortedLabels   : editLists?.sortedLabels]
@@ -715,7 +716,7 @@ class ProjectController {
                 def editLists = getGeneralProjectLists(project)
                 render(view: "editGeneralSettings", model: [projectInstance: project,
                                                             templates      : editLists?.templates,
-                                                            projectTypes   : ProjectType.listOrderByName(),
+                                                            projectTypes   : projectTypeService.getEnabledProjectTypes(project.projectType),
                                                             institutionList: editLists?.insts,
                                                             labelColourMap : editLists?.catColourMap,
                                                             sortedLabels   : editLists?.sortedLabels])

--- a/grails-app/controllers/au/org/ala/volunteer/TemplateController.groovy
+++ b/grails-app/controllers/au/org/ala/volunteer/TemplateController.groovy
@@ -107,7 +107,7 @@ class TemplateController {
                 return
             }
 
-            def availableViews = templateService.getAvailableTemplateViews()
+            def availableViews = templateService.getAvailableTemplateViews(template.viewName)
             def projectUsageList = [:]
             def projectList = template.projects.sort { a, b -> a.institution?.name <=> b.institution?.name }
             def institutionName = ""

--- a/grails-app/domain/au/org/ala/volunteer/ProjectType.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/ProjectType.groovy
@@ -13,6 +13,8 @@ class ProjectType implements Serializable {
 
     static hasMany = [projects: Project, landingPages: LandingPage]
 
+    public static final List<String> DISABLED_TYPES = [PROJECT_TYPE_AUDIO]
+
     static constraints = {
         name nullable: false
         label nullable: false

--- a/grails-app/domain/au/org/ala/volunteer/Template.groovy
+++ b/grails-app/domain/au/org/ala/volunteer/Template.groovy
@@ -34,13 +34,15 @@ class Template implements Serializable {
         isHidden defaultValue: 'false'
     }
 
+    public static final List<String> DISABLED_VIEWS = ['audioTranscribe']
+
     String toString() {
         //return "Template: ${name}, [view: ${viewName}, isGlobal: ${isGlobal}, isHidden: ${isHidden}, Project Count: ${projects.size()}]"
         return "${name}" + (isGlobal ? " (Global)" : "") + (isHidden ? " (Hidden)" : "") + (projects.size() == 0 ? " (Unassigned)" : "")
     }
 
     def getTemplateMap() {
-        return [id: id, name: name, isGlobal: isGlobal, isHidden: isHidden]
+        return [id: id, name: name, viewName: viewName, isGlobal: isGlobal, isHidden: isHidden]
     }
 
 }

--- a/grails-app/services/au/org/ala/volunteer/ProjectTypeService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ProjectTypeService.groovy
@@ -42,4 +42,19 @@ class ProjectTypeService {
         return "${grailsApplication.config.getProperty('server.url', String)}/${grailsApplication.config.getProperty('images.urlPrefix', String)}projectType/${projectType.name}.png"
     }
 
+    /**
+     * Returns a list of project types that are enabled for use. This is used to filter out project
+     * types that are not currently supported or should not be available for selection when creating or editing
+     * projects.
+     */
+    def getEnabledProjectTypes(ProjectType projectType = null) {
+        def projectTypes = ProjectType.listOrderByName()
+
+        // Check ProjectType.DISABLED_TYPES for disabled types and remove them from the list before returning. If the
+        // provided projectType is in the disabled list, then do not remove it.
+        projectTypes.removeAll { ProjectType.DISABLED_TYPES.contains(it.name) && it.name != projectType?.name }
+        //log.debug("Enabled project types: ${projectTypes*.name}")
+
+        return projectTypes
+    }
 }

--- a/grails-app/services/au/org/ala/volunteer/ProjectTypeService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/ProjectTypeService.groovy
@@ -52,9 +52,11 @@ class ProjectTypeService {
 
         // Check ProjectType.DISABLED_TYPES for disabled types and remove them from the list before returning. If the
         // provided projectType is in the disabled list, then do not remove it.
-        projectTypes.removeAll { ProjectType.DISABLED_TYPES.contains(it.name) && it.name != projectType?.name }
+        def enabledProjectTypes = projectTypes.findAll {
+            !ProjectType.DISABLED_TYPES.contains(it.name) || it.name == projectType?.name
+        }
         //log.debug("Enabled project types: ${projectTypes*.name}")
 
-        return projectTypes
+        return enabledProjectTypes
     }
 }

--- a/grails-app/services/au/org/ala/volunteer/TemplateService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/TemplateService.groovy
@@ -69,15 +69,27 @@ class TemplateService {
         return views
     }
 
-    def getAvailableTemplateViews() {
+    /**
+     * Returns a list of available template views by checking the GSPs in the templateViews folder. This is used to
+     * populate the dropdown for selecting a template view when creating/editing templates, and also to filter out
+     * templates using views that are no longer supported.
+     * @param selectedViewName the view name of the currently selected template
+     * @return a list of available template view names (without the .gsp suffix)
+     */
+    def getAvailableTemplateViews(String selectedViewName = null) {
         def views = []
         def pattern
 
         if (Environment.isDevelopmentEnvironmentAvailable()) {
             log.debug("Checking for dev templates")
             findDevGsps 'grails-app/views/transcribe/templateViews', views
-            // This is a pattern for windows... linux developer would have to modify?
-            pattern = Pattern.compile("^grails-app\\\\views\\\\transcribe\\\\templateViews\\\\(.*Transcribe)[.]gsp\$")
+            // Set pattern for extracting view name from path. Windows paths are different to Linux/Mac, so need to
+            // assign accordingly.
+            if (System.getProperty("os.name").toLowerCase().contains("win")) {
+                pattern = Pattern.compile("^grails-app\\\\views\\\\transcribe\\\\templateViews\\\\(.*Transcribe)[.]gsp\$")
+            } else {
+                pattern = Pattern.compile("^transcribe/templateViews/(.*Transcribe)[.]gsp\$")
+            }
         } else {
             log.debug("Checking for WAR deployed templates")
             findWarGsps '/WEB-INF/grails-app/views/transcribe/templateViews', views
@@ -91,7 +103,11 @@ class TemplateService {
             m.matches() ? [m.group(1)] : []
         }.sort()
 
-        log.debug("Views after collect/sort: {}", results)
+        // DG-216 Remove views in Template.DISABLED_VIEWS from the list of available templates, as it is not currently supported,
+        // unless it is the selected view, in which case it needs to be included so that the template can still be edited.
+        results.removeAll { Template.DISABLED_VIEWS.contains(it) && it != selectedViewName }
+
+        log.debug("Views after collect/sort: ${results}")
         return results
     }
 
@@ -151,7 +167,16 @@ class TemplateService {
      * @return the list of templates.
      */
     def getTemplatesForProject(Project project, boolean includeHidden = false, boolean concise = false) {
-        return getTemplatesForInstitution(project.institution, project.template.id, includeHidden, concise)
+        def templates = []
+        templates = getTemplatesForInstitution(project.institution, project.template.id, includeHidden, concise)
+
+        // We must remove any template using disabled views in Template.DISABLED_VIEWS except where the current project's
+        // template or other templates are using that view.
+        def templateViews = getAvailableTemplateViews(project.template.viewName)
+        templates.removeAll {
+            !templateViews.contains(it.template.viewName)
+        }
+        return templates
     }
 
     /**
@@ -164,7 +189,12 @@ class TemplateService {
      * @return a list of available templates
      */
     def getTemplatesForInstitution(Institution institution, boolean includeHidden = false, boolean concise = false) {
-        return getTemplatesForInstitution(institution, 0L, includeHidden, concise)
+        def templates = getTemplatesForInstitution(institution, 0L, includeHidden, concise)
+
+        // Remove disabled templates in Template.DISABLED_VIEWS.
+        templates.removeAll { Template.DISABLED_VIEWS.contains(it.template.viewName) }
+
+        return templates
     }
 
     /**

--- a/grails-app/services/au/org/ala/volunteer/TemplateService.groovy
+++ b/grails-app/services/au/org/ala/volunteer/TemplateService.groovy
@@ -105,10 +105,10 @@ class TemplateService {
 
         // DG-216 Remove views in Template.DISABLED_VIEWS from the list of available templates, as it is not currently supported,
         // unless it is the selected view, in which case it needs to be included so that the template can still be edited.
-        results.removeAll { Template.DISABLED_VIEWS.contains(it) && it != selectedViewName }
+        def enabledTemplates = results.findAll { !Template.DISABLED_VIEWS.contains(it) || it == selectedViewName }
 
         log.debug("Views after collect/sort: ${results}")
-        return results
+        return enabledTemplates
     }
 
     /**
@@ -173,10 +173,11 @@ class TemplateService {
         // We must remove any template using disabled views in Template.DISABLED_VIEWS except where the current project's
         // template or other templates are using that view.
         def templateViews = getAvailableTemplateViews(project.template.viewName)
-        templates.removeAll {
-            !templateViews.contains(it.template.viewName)
-        }
-        return templates
+        def enabledTemplates = templates.findAll { templateViews.contains(it.template.viewName) }
+//        templates.removeAll {
+//            !templateViews.contains(it.template.viewName)
+//        }
+        return enabledTemplates
     }
 
     /**


### PR DESCRIPTION
 - Added capability to 'disable' project types.
 - Added capability to 'disable' template views.
 - Disabled audio project type and audioTranscribe template view.
 - Disabled project types and template views should no longer be able to be created or assigned.
 - Functionality allows for pre-existing projects and templates that use disabled project types/views at the time of disabling to continue to be accessible/edited.
